### PR TITLE
chore: update package name to gomake & update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,45 @@
 # go-make
 
-A golang-based build script library, with a goals of having very few dependencies 
-and enabling consistent cross-platform build scripts.
+A golang-based build script library, with a goals of having very few dependencies for fast execution time 
+and enabling consistent, cross-platform build scripts.
 
 ## Example
 
-See [the build definition in this repository](make/main.go)
-
 ```golang
-package main
+package main // file: make/main.go
 
 import (
 	. "github.com/anchore/go-make"
-	. "github.com/anchore/go-make/tasks"
+	"github.com/anchore/go-make/golint"
+	"github.com/anchore/go-make/gotest"
 )
 
 func main() {
-  Makefile(
-    LintFix, // share tasks
-    Task{ // define tasks that feel somewhat like scripts
-      Name: "format",
-      Desc: "format all source files",
-      Run: func() {
-        Run(`gofmt -w -s .`)
-        Run(`gosimports -local github.com/anchore -w .`)
-        Run(`go mod tidy`)
-      },
-    },
-  )
+	Makefile(
+		golint.Tasks(), // centralize common task definitions 
+		gotest.Test("unit"),
+		// define tasks that feel somewhat like configuration / scripts:
+		Task{
+			Name: "build",
+			Desc:  "make a custom build task",
+			Deps:  All("goreleaser:snapshot-buildfile"), // can ensure other specific tasks run first, like make dependencies
+			Run: func() {
+				// Run function supports: global template vars, quoting within strings,
+				// obtaining & providing binny-managed executable
+				Run(`goreleaser build --config {{TmpDir}}/goreleaser.yaml --clean --snapshot --single-target`)
+			},
+		},
+		Task{
+			Name:  "custom-tests",
+			Desc:  "do some custom formatting stuff",
+			Label: All("test"),  // runs whenever "test" runs, e.g. make test
+			Run: func() {
+				// failed commands have convenient links here, in this file
+				Run(`go test ./test`)
+			},
+		},
+	)
 }
 ```
+
+Also, see [the build definition in this repository](make/main.go)

--- a/binny.go
+++ b/binny.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"archive/tar"

--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"fmt"

--- a/exec.go
+++ b/exec.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"bytes"

--- a/fetch.go
+++ b/fetch.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"io"

--- a/file.go
+++ b/file.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/anchore/go-make/color"
 )
 
 // RootDir is a function to return the root directory which builds run from
@@ -25,6 +27,19 @@ func Cd(dir string) {
 // Cwd returns the current working directory
 func Cwd() string {
 	return Get(os.Getwd())
+}
+
+// Rmdir removes the given directory, first verifying it is a subdirectory of RootDir
+func Rmdir(dir string) {
+	dirToRm := Get(filepath.Abs(dir))
+	rootDir := Get(filepath.Abs(RootDir()))
+
+	if strings.HasPrefix(dirToRm, rootDir) {
+		Log(color.Red(`go: rm -rf %v`), dirToRm)
+		NoErr(os.RemoveAll(dirToRm))
+	} else {
+		Throw(fmt.Errorf("directory '%s' not in RootDir: '%s'", dirToRm, rootDir))
+	}
 }
 
 // InDir executes the given function in the provided directory, returning to the current working directory upon completion

--- a/file.go
+++ b/file.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"crypto/md5" //nolint: gosec

--- a/git.go
+++ b/git.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"bytes"

--- a/gomod.go
+++ b/gomod.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"os"

--- a/gomod_test.go
+++ b/gomod_test.go
@@ -1,4 +1,4 @@
-package make_test
+package gomake_test
 
 import (
 	"os"

--- a/help.go
+++ b/help.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"fmt"

--- a/repo_root.go
+++ b/repo_root.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 func RepoRoot() string {
 	return GitRoot()

--- a/shell_split.go
+++ b/shell_split.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"strings"

--- a/shell_split_test.go
+++ b/shell_split_test.go
@@ -1,4 +1,4 @@
-package make_test
+package gomake_test
 
 import (
 	"testing"

--- a/tasks.go
+++ b/tasks.go
@@ -43,11 +43,21 @@ func Makefile(tasks ...Task) {
 		Run:  t.Help,
 	})
 
+	t.tasks = append(t.tasks, &Task{
+		Name:   "binny:clean",
+		Desc:   "clean binny cache",
+		Labels: All("clean"),
+		Quiet:  true,
+		Run: func() {
+			Rmdir(".tool")
+		},
+	})
+
 	// t.tasks = append(t.tasks, &Task{
 	//	Name: "makefile",
 	//	Desc: "generate an explicit Makefile for all tasks",
 	//	Run:  t.Makefile,
-	//})
+	// })
 
 	readEnvironmentVars()
 

--- a/tasks.go
+++ b/tasks.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"fmt"

--- a/tasks/release/release.go
+++ b/tasks/release/release.go
@@ -27,6 +27,7 @@ func CIReleaseTask() Task {
 	return Task{
 		Name: "ci-release",
 		Desc: "build and publish a release with goreleaser",
+		Deps: All("dependencies:quill", "dependencies:syft"),
 		Run: func() {
 			EnsureFileExists(configName)
 
@@ -36,6 +37,7 @@ func CIReleaseTask() Task {
 
 			Run(fmt.Sprintf(`goreleaser release --clean --snapshot --releasenotes %s`, changelogFile))
 		},
+		Tasks: []Task{quillInstallTask(), syftInstallTask()},
 	}
 }
 
@@ -58,5 +60,29 @@ func ensureHeadHasTag() {
 func failIfNotInCI() {
 	if os.Getenv("CI") == "" {
 		Throw(errors.New("this task can only be run in CI"))
+	}
+}
+
+func quillInstallTask() Task {
+	return Task{
+		Name:  "dependencies:quill",
+		Quiet: true,
+		Run: func() {
+			if IsBinnyManagedTool("quill") {
+				_ = BinnyInstall("quill")
+			}
+		},
+	}
+}
+
+func syftInstallTask() Task {
+	return Task{
+		Name:  "dependencies:syft",
+		Quiet: true,
+		Run: func() {
+			if IsBinnyManagedTool("syft") {
+				_ = BinnyInstall("syft")
+			}
+		},
 	}
 }

--- a/tasks/release/snapshot.go
+++ b/tasks/release/snapshot.go
@@ -11,6 +11,7 @@ func SnapshotTask() Task {
 	return Task{
 		Name: "snapshot",
 		Desc: "build a snapshot release with goreleaser",
+		Deps: All("dependencies:quill", "dependencies:syft"),
 		Run: func() {
 			EnsureFileExists(configName)
 
@@ -34,8 +35,7 @@ func SnapshotTask() Task {
 				Desc:   "clean all snapshots",
 				Labels: All("clean"),
 				Run: func() {
-					snapshotDir := PathJoin(RepoRoot(), "snapshot")
-					Run(`rm -rf`, snapshotDir)
+					Rmdir("snapshot")
 				},
 			},
 		},

--- a/tool.go
+++ b/tool.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"bytes"

--- a/util.go
+++ b/util.go
@@ -1,4 +1,4 @@
-package make
+package gomake
 
 import (
 	"fmt"

--- a/util_test.go
+++ b/util_test.go
@@ -1,4 +1,4 @@
-package make_test
+package gomake_test
 
 import (
 	"os"


### PR DESCRIPTION
This PR makes a couple changes:
* updates the package name to `gomake`
* updates the README to include a bit more example