### PR TITLE
chore(deps): restore Go version to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/go-make
 
-go 1.26.2
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0


### PR DESCRIPTION
Restores the go directive in go.mod to 1.25.0 (pre-#69). Bumped in #69 (merge e7e2d29c8b2e304f0edddf371274bea003c7a597).