### PR TITLE
Tighten workflow-level permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,6 @@
 name: "Release"
 
-permissions:
-  contents: read
-  checks: read
+permissions: {}
 
 concurrency:
   group: release
@@ -23,6 +21,8 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    permissions:
+      checks: read
     uses: anchore/workflows/.github/workflows/check-gate.yaml@4f25313f96311410cad4173f74617654a3e46d48 # v0.3.0
     with:
       checks: '["Static analysis", "Unit tests", "Integration tests"]'

--- a/.github/workflows/validate-github-actions.yaml
+++ b/.github/workflows/validate-github-actions.yaml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/**'
       - '.github/actions/**'
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   zizmor:

--- a/.github/workflows/validations.yaml
+++ b/.github/workflows/validations.yaml
@@ -10,13 +10,14 @@ on:
     # run once per week so we always have an artifact for testing and get notified of new versions causing issues
     - cron: 0 0 * * 0
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   Static-Analysis:
     name: "Static analysis"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -36,6 +37,8 @@ jobs:
   Integration-Tests:
     name: "Integration tests"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
@@ -47,6 +50,8 @@ jobs:
 
   Tests:
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         os:


### PR DESCRIPTION
Move all workflow-level permissions blocks to the job level so each job only holds the minimum it actually needs.

Changes:
- release.yaml: top-level permissions → `{}`, `checks: read` moved to the `check-gate` job
- validate-github-actions.yaml: top-level permissions → `{}` (zizmor job already had its own job-level block)
- validations.yaml: top-level permissions → `{}`, `contents: read` pushed down to Static-Analysis, Integration-Tests, and Tests jobs

Notes:
- Unit-Tests job only runs `echo` and does no checkout, so it needs no permissions block