### PR TITLE
Bump chronicle version + add other tools

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -18,10 +18,34 @@ tools:
   # used at release to generate the changelog
   - name: chronicle
     version:
-      want: v0.8.3
+      want: v0.9.0
     method: github-release
     with:
       repo: anchore/chronicle
+
+  # used to produce SBOMs during release
+  - name: syft
+    version:
+      want: v1.42.3
+    method: github-release
+    with:
+      repo: anchore/syft
+
+  # used to sign mac binaries at release
+  - name: quill
+    version:
+      want: v0.7.1
+    method: github-release
+    with:
+      repo: anchore/quill
+
+  # used for signing the checksums file at release
+  - name: cosign
+    version:
+      want: v3.0.5
+    method: github-release
+    with:
+      repo: sigstore/cosign
 
   # used for linting
   - name: golangci-lint
@@ -46,14 +70,6 @@ tools:
     method: github-release
     with:
       repo: wagoodman/go-bouncer
-
-  # used for showing the changelog at release
-  - name: glow
-    version:
-      want: v2.1.2
-    method: github-release
-    with:
-      repo: charmbracelet/glow
 
   # used for running all local and CI tasks
   - name: task

--- a/tasks/release/changelog.go
+++ b/tasks/release/changelog.go
@@ -5,9 +5,7 @@ import (
 	"os"
 
 	. "github.com/anchore/go-make"
-	"github.com/anchore/go-make/binny"
 	"github.com/anchore/go-make/file"
-	"github.com/anchore/go-make/lang"
 	"github.com/anchore/go-make/log"
 	"github.com/anchore/go-make/run"
 )
@@ -45,16 +43,11 @@ func GenerateAndShowChangelog() (changelogFilePath, versionFilePath string) {
 	ghAuthToken := Run("gh auth token")
 	log.Debug("Auth token: %.10s...", ghAuthToken)
 
-	changelog := Run("chronicle -n --version-file", run.Args(versionFile), run.Env("GITHUB_TOKEN", ghAuthToken))
-
-	file.Write(changelogFile, changelog)
-
-	// render the changelog with glow if available
-	if binny.IsManagedTool("glow") {
-		// without -s dark, it will defailt to no style since it cannot detect a tty with this approach
-		changelog = Run(fmt.Sprintf(`glow -s dark -w 0 %s`, changelogFile))
-	}
-	lang.Return(os.Stderr.WriteString(changelog))
+	Run(
+		fmt.Sprintf(`chronicle -n -o version=%s -o md=%s -o md-pretty`, versionFile, changelogFile),
+		run.Stdout(os.Stderr),
+		run.Env("GITHUB_TOKEN", ghAuthToken),
+	)
 
 	return changelogFile, versionFile
 }
@@ -69,16 +62,11 @@ func GenerateAndShowFromVersion(version string) string {
 	ghAuthToken := Run("gh auth token")
 	log.Debug("Auth token: %.10s...", ghAuthToken)
 
-	changelog := Run("chronicle --until-tag", run.Args(version), run.Env("GITHUB_TOKEN", ghAuthToken))
-
-	file.Write(changelogFile, changelog)
-
-	// render the changelog with glow if available
-	if binny.IsManagedTool("glow") {
-		// without -s dark, it will default to no style since it cannot detect a tty with this approach
-		changelog = Run(fmt.Sprintf(`glow -s dark -w 0 %s`, changelogFile))
-	}
-	lang.Return(os.Stderr.WriteString(changelog))
+	Run(
+		fmt.Sprintf(`chronicle -n --until-tag %s -o md=%s -o md-pretty`, version, changelogFile),
+		run.Stdout(os.Stderr),
+		run.Env("GITHUB_TOKEN", ghAuthToken),
+	)
 
 	return changelogFile
 }


### PR DESCRIPTION
This PR:
- bumps chronicle version
- drops glow and uses new output format from chronicle
- adds syft, quill, and cosign for other consumers to inherit