### PR TITLE
Publish tags in ci-release tasks

### DIFF
--- a/internal/ci/check.go
+++ b/internal/ci/check.go
@@ -1,0 +1,9 @@
+package ci
+
+import "os"
+
+func EnsureInCI() {
+	if os.Getenv("CI") != "true" {
+		panic("this task must be run in CI (CI=true)")
+	}
+}

--- a/internal/ci/publish_tag.go
+++ b/internal/ci/publish_tag.go
@@ -1,0 +1,41 @@
+package ci
+
+import (
+	"os"
+
+	"github.com/anchore/go-make/git"
+	"github.com/anchore/go-make/lang"
+	"github.com/anchore/go-make/log"
+)
+
+func PublishTag(tagName, deployKey string) {
+	EnsureInCI()
+
+	repository := os.Getenv("GITHUB_REPOSITORY")
+	if repository == "" {
+		panic("GITHUB_REPOSITORY environment variable must be set (e.g 'org/reponame')")
+	}
+
+	tagMessage := lang.Default(os.Getenv("TAG_MESSAGE"), "Release "+tagName)
+	gitUserName := lang.Default(os.Getenv("GIT_USER_NAME"), "github-actions[bot]")
+	gitUserEmail := lang.Default(os.Getenv("GIT_USER_EMAIL"), "github-actions[bot]@users.noreply.github.com")
+
+	// create the tag locally first (no deploy key needed)
+	sha := git.CreateTag(git.CreateTagConfig{
+		Tag:          tagName,
+		TagMessage:   tagMessage,
+		GitUserName:  gitUserName,
+		GitUserEmail: gitUserEmail,
+	})
+
+	log.Info("created local tag %s at %s", tagName, sha)
+
+	// push the tag to remote (needs deploy key)
+	git.PushTag(git.PushTagConfig{
+		Tag:        tagName,
+		DeployKey:  deployKey,
+		Repository: repository,
+	})
+
+	log.Info("pushed tag %s to remote", tagName)
+}

--- a/internal/ci/release_inputs.go
+++ b/internal/ci/release_inputs.go
@@ -1,0 +1,25 @@
+package ci
+
+import (
+	"os"
+	"regexp"
+)
+
+func ReleaseInputs() (string, string) {
+	deployKey := os.Getenv("DEPLOY_KEY")
+	if deployKey == "" {
+		panic("DEPLOY_KEY environment variable must be set")
+	}
+
+	tagName := os.Getenv("RELEASE_VERSION")
+	if tagName == "" {
+		panic("RELEASE_VERSION environment variable must be set")
+	}
+
+	// validate version format early before doing any work
+	if !regexp.MustCompile(`^v\d+\.\d+\.\d+`).MatchString(tagName) {
+		panic("RELEASE_VERSION does not appear to be a valid semver (e.g. v1.2.3)")
+	}
+
+	return tagName, deployKey
+}

--- a/tasks/goreleaser/release.go
+++ b/tasks/goreleaser/release.go
@@ -1,14 +1,10 @@
 package goreleaser
 
 import (
-	"errors"
-	"os"
-	"strings"
-
 	. "github.com/anchore/go-make"
 	"github.com/anchore/go-make/binny"
 	"github.com/anchore/go-make/file"
-	"github.com/anchore/go-make/log"
+	"github.com/anchore/go-make/internal/ci"
 	"github.com/anchore/go-make/run"
 	"github.com/anchore/go-make/tasks/release"
 )
@@ -21,16 +17,17 @@ func Tasks() Task {
 	return Task{
 		Tasks: []Task{
 			SnapshotTasks(),
-			CIReleaseTask(),
+			ReleaseTask(),
 			release.WorkflowReleaseTask(),
+			release.ChangelogTask(),
 		},
 	}
 }
 
-// CIReleaseTask creates a task for running goreleaser in CI environments.
+// ReleaseTask creates a task for running goreleaser in CI environments.
 // Requires CI=true, a version tag on HEAD, and optional quill/syft tools
 // for signing and SBOM generation.
-func CIReleaseTask() Task {
+func ReleaseTask() Task {
 	return Task{
 		Name:         "ci-release",
 		Description:  "build and publish a release with goreleaser",
@@ -38,8 +35,9 @@ func CIReleaseTask() Task {
 		Run: func() {
 			file.Require(configName)
 
-			failIfNotInCI()
-			ensureHeadHasTag()
+			tagName, deployKey := ci.ReleaseInputs()
+
+			ci.PublishTag(tagName, deployKey)
 			changelogFile, _ := release.GenerateAndShowChangelog()
 
 			Run(`goreleaser release --clean --release-notes`, run.Args(changelogFile))
@@ -49,25 +47,6 @@ func CIReleaseTask() Task {
 			Description:  "ensure all release dependencies are installed",
 			Dependencies: Deps("dependencies:quill", "dependencies:syft"),
 		}},
-	}
-}
-
-func ensureHeadHasTag() {
-	tags := strings.Split(Run("git tag --points-at HEAD"), "\n")
-
-	for _, tag := range tags {
-		if strings.HasPrefix(tag, "v") {
-			log.Info("HEAD has a version tag: %s", tag)
-			return
-		}
-	}
-
-	panic(errors.New("HEAD does not have a tag that starts with 'v'"))
-}
-
-func failIfNotInCI() {
-	if os.Getenv("CI") == "" {
-		panic(errors.New("this task can only be run in CI"))
 	}
 }
 

--- a/tasks/release/tag_and_create_gh_release.go
+++ b/tasks/release/tag_and_create_gh_release.go
@@ -1,13 +1,8 @@
 package release
 
 import (
-	"os"
-	"regexp"
-
 	. "github.com/anchore/go-make"
-	"github.com/anchore/go-make/git"
-	"github.com/anchore/go-make/lang"
-	"github.com/anchore/go-make/log"
+	"github.com/anchore/go-make/internal/ci"
 	"github.com/anchore/go-make/run"
 )
 
@@ -28,55 +23,13 @@ func TagAndCreateGHRelease() Task {
 		Name:        "ci-release",
 		Description: "creates a GitHub release (to be run in CI only)",
 		Run: func() {
-			if os.Getenv("CI") != "true" {
-				panic("this task must be run in CI (CI=true)")
-			}
+			tagName, deployKey := ci.ReleaseInputs()
 
-			deployKey := os.Getenv("DEPLOY_KEY")
-			if deployKey == "" {
-				panic("DEPLOY_KEY environment variable must be set")
-			}
-
-			tagName := os.Getenv("RELEASE_VERSION")
-			if tagName == "" {
-				panic("RELEASE_VERSION environment variable must be set")
-			}
-
-			// validate version format early before doing any work
-			if !regexp.MustCompile(`^v\d+\.\d+\.\d+`).MatchString(tagName) {
-				panic("RELEASE_VERSION does not appear to be a valid semver (e.g. v1.2.3)")
-			}
-
-			repository := os.Getenv("GITHUB_REPOSITORY")
-			if repository == "" {
-				panic("GITHUB_REPOSITORY environment variable must be set (e.g 'org/reponame')")
-			}
-
-			tagMessage := lang.Default(os.Getenv("TAG_MESSAGE"), "Release "+tagName)
-			gitUserName := lang.Default(os.Getenv("GIT_USER_NAME"), "github-actions[bot]")
-			gitUserEmail := lang.Default(os.Getenv("GIT_USER_EMAIL"), "github-actions[bot]@users.noreply.github.com")
-
-			// create the tag locally first (no deploy key needed)
-			sha := git.CreateTag(git.CreateTagConfig{
-				Tag:          tagName,
-				TagMessage:   tagMessage,
-				GitUserName:  gitUserName,
-				GitUserEmail: gitUserEmail,
-			})
-
-			log.Info("created local tag %s at %s", tagName, sha)
+			// this ensures we are in CI and will tag HEAD and push using the deploy key
+			ci.PublishTag(tagName, deployKey)
 
 			// generate changelog for the version (needs the tag to exist locally)
 			changelogFile := GenerateAndShowFromVersion(tagName)
-
-			// push the tag to remote (needs deploy key)
-			git.PushTag(git.PushTagConfig{
-				Tag:        tagName,
-				DeployKey:  deployKey,
-				Repository: repository,
-			})
-
-			log.Info("pushed tag %s to remote", tagName)
 
 			// use --verify-tag to abort if the tag doesn't already exist on remote
 			Run("gh release create --latest --verify-tag",


### PR DESCRIPTION
This migrates any publishing of tags to always be within `ci-release` tasks and ensures they always have the same expected input.