### PR TITLE
Use restore only cache patterns on non-default branches

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,6 +1,6 @@
-# Restore-only caching pattern: PRs read existing caches but never write back; only the
-# repo's default branch (`github.event.repository.default_branch`) refreshes them. This
-# keeps untrusted PR runs from polluting or evicting trusted cache entries.
+# Restore-only caching pattern: PRs (and pushes to fork default branches) read existing
+# caches but never write back. Only pushes to the upstream repo's default branch refresh
+# them. This keeps untrusted runs from polluting or evicting trusted cache entries.
 #
 # See: https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#restore-only-caches
 # and: https://github.com/actions/cache/tree/main/restore#only-restore-cache
@@ -50,7 +50,7 @@ runs:
 
     # go build/mod cache: restore-only on non-default branches
     - name: Restore go build/mod cache
-      if: ${{ inputs.cache-enabled == 'true' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+      if: ${{ inputs.cache-enabled == 'true' && (github.ref != format('refs/heads/{0}', github.event.repository.default_branch) || github.event.repository.fork == true) }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
@@ -62,7 +62,7 @@ runs:
 
     # go build/mod cache: restore + save on the cache-update branch
     - name: Restore and save go build/mod cache
-      if: ${{ inputs.cache-enabled == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      if: ${{ inputs.cache-enabled == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.repository.fork == false }}
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: |
@@ -75,7 +75,7 @@ runs:
     # tool cache: restore-only on non-default branches
     - name: Restore tool cache
       id: tool-cache
-      if: ${{ inputs.cache-enabled == 'true' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+      if: ${{ inputs.cache-enabled == 'true' && (github.ref != format('refs/heads/{0}', github.event.repository.default_branch) || github.event.repository.fork == true) }}
       uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ github.workspace }}/.tool
@@ -86,7 +86,7 @@ runs:
     # tool cache: restore + save on the cache-update branch
     - name: Restore and save tool cache
       id: tool-cache-rw
-      if: ${{ inputs.cache-enabled == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      if: ${{ inputs.cache-enabled == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.repository.fork == false }}
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ github.workspace }}/.tool

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,3 +1,9 @@
+# Restore-only caching pattern: PRs read existing caches but never write back; only the
+# repo's default branch (`github.event.repository.default_branch`) refreshes them. This
+# keeps untrusted PR runs from polluting or evicting trusted cache entries.
+#
+# See: https://github.com/actions/setup-go/blob/main/docs/advanced-usage.md#restore-only-caches
+# and: https://github.com/actions/cache/tree/main/restore#only-restore-cache
 name: "Setup go & go-make"
 description: "Setup go & go-make"
 inputs:
@@ -15,6 +21,9 @@ inputs:
   cache-key-prefix:
     description: "Prefix all cache keys with this value"
     default: "v1"
+  cache-enabled:
+    description: "Enable build/mod and tool caching. When disabled, no restore or save."
+    default: "true"
 runs:
   using: "composite"
   steps:
@@ -27,10 +36,57 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
         go-version-file: ${{ !inputs.go-version && inputs.go-version-file || '' }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        # we manage the go build/mod cache below so we can restore-only on non-default branches
+        cache: false
         check-latest: true
+
+    # capture go cache paths for the cache actions below
+    - name: Resolve go cache paths
+      if: ${{ inputs.cache-enabled == 'true' }}
+      shell: bash
+      run: |
+        echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
+        echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> "$GITHUB_ENV"
+
+    # go build/mod cache: restore-only on non-default branches
+    - name: Restore go build/mod cache
+      if: ${{ inputs.cache-enabled == 'true' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.arch }}-${{ runner.os }}-go-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.arch }}-${{ runner.os }}-go-
+
+    # go build/mod cache: restore + save on the cache-update branch
+    - name: Restore and save go build/mod cache
+      if: ${{ inputs.cache-enabled == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: |
+          ${{ env.GO_MOD_CACHE }}
+          ${{ env.GO_BUILD_CACHE }}
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.arch }}-${{ runner.os }}-go-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.arch }}-${{ runner.os }}-go-
+
+    # tool cache: restore-only on non-default branches
     - name: Restore tool cache
       id: tool-cache
+      if: ${{ inputs.cache-enabled == 'true' && github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
+      uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: ${{ github.workspace }}/.tool
+        key: ${{ inputs.cache-key-prefix }}-${{ runner.arch }}-${{ runner.os }}-tool-${{ hashFiles('.binny.yaml') }}
+        restore-keys: |
+          ${{ inputs.cache-key-prefix }}-${{ runner.arch }}-${{ runner.os }}-tool
+
+    # tool cache: restore + save on the cache-update branch
+    - name: Restore and save tool cache
+      id: tool-cache-rw
+      if: ${{ inputs.cache-enabled == 'true' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ github.workspace }}/.tool


### PR DESCRIPTION
This is meant to block non-default branches from being able to write to the go and tool caches by default. Additionally caching can be entirely disabled by the caller.