### PR TITLE
chore: Make partitioned release tasks

### DIFF
--- a/.make/main.go
+++ b/.make/main.go
@@ -17,8 +17,7 @@ func main() {
 	Makefile(
 		golint.Tasks(),
 		gotest.Tasks(),
-		release.ChangelogTask(),
-		release.TagAndCreateGHRelease(),
+		release.Tasks(),
 		Task{
 			Name:        "generate:github-ssh-keys",
 			Description: "refresh GitHub SSH known_hosts from the GitHub meta API",

--- a/tasks/goreleaser/release.go
+++ b/tasks/goreleaser/release.go
@@ -16,10 +16,10 @@ const configName = ".goreleaser.yaml"
 func Tasks() Task {
 	return Task{
 		Tasks: []Task{
-			SnapshotTasks(),
-			ReleaseTask(),
-			release.WorkflowReleaseTask(),
-			release.ChangelogTask(),
+			SnapshotTasks(),               // `make snapshot` to build a local snapshot to ./snapshot
+			ReleaseTask(),                 // `make ci-release` for building and publishing a release with goreleaser
+			release.WorkflowReleaseTask(), // `make release` to trigger the release.yaml workflow
+			release.ChangelogTask(),       // `make changelog` to generate and show changes since the last release
 		},
 	}
 }

--- a/tasks/release/release.go
+++ b/tasks/release/release.go
@@ -2,11 +2,24 @@ package release
 
 import (
 	. "github.com/anchore/go-make"
+	"github.com/anchore/go-make/file"
 	"github.com/anchore/go-make/internal/ci"
 	"github.com/anchore/go-make/run"
 )
 
-// TagAndCreateGHRelease creates a git tag and GitHub release for a specific version.
+// Tasks creates the complete release task group including changelog generation,
+// CI releases (publish tag + gh release... NOT goreleaser), and workflow triggers.
+func Tasks() Task {
+	return Task{
+		Tasks: []Task{
+			ChangelogTask(),       // `make chanagelog` to generate and show changes since the last release
+			WorkflowReleaseTask(), // `make release` to trigger the release.yaml workflow
+			TagReleaseTask(),      // `make ci-release` for publishing a tag and creating a GH release
+		},
+	}
+}
+
+// TagReleaseTask creates a git tag and GitHub release for a specific version.
 // This task is designed to run in CI with GitHub's release environment, which provides
 // deploy key SSH secrets for tag control. This approach is necessary because repository
 // rulesets typically prevent direct tag pushes, so we use a deploy key with write access
@@ -18,11 +31,13 @@ import (
 //  3. Generate the changelog using chronicle with --until-tag
 //  4. Push the tag to remote using the deploy key
 //  5. Create the GitHub release with the changelog
-func TagAndCreateGHRelease() Task {
+func TagReleaseTask() Task {
 	return Task{
 		Name:        "ci-release",
 		Description: "creates a GitHub release (to be run in CI only)",
 		Run: func() {
+			ensureNoGoreleaserConfig()
+
 			tagName, deployKey := ci.ReleaseInputs()
 
 			// this ensures we are in CI and will tag HEAD and push using the deploy key
@@ -36,5 +51,21 @@ func TagAndCreateGHRelease() Task {
 				run.Args(tagName, "--notes-file", changelogFile, "--title", tagName),
 			)
 		},
+	}
+}
+
+// TagAndCreateGHRelease is a convenience alias for TagAndCreateGHReleaseTask to simplify the Makefile.
+//
+// Deprecated: please use TagReleaseTask
+func TagAndCreateGHRelease() Task {
+	return TagReleaseTask()
+}
+
+func ensureNoGoreleaserConfig() {
+	// this release flow is for library-only projects; the presence of a goreleaser
+	// config hints at one or more distributables, which means this is probably a tool
+	// and should be using the goreleaser-backed release task instead.
+	if file.Exists(".goreleaser.yaml") {
+		panic(".goreleaser.yaml found: this release task is for library-only projects; use the goreleaser release task instead")
 	}
 }


### PR DESCRIPTION
This does a couple of things:
- I didn't quite follow the convention for naming tasks when introducing `TagAndCreateGHRelease `, so this is take 2 at that.
- adds a `release.Tasks()` helper for libs to be able to use. I was worried earlier about this being used in cases it's not meant for (tools instead of libs) but with a very simple "is there a .goreleaser.yaml file?" check it isn't really possible to misuse this now.