### PR TITLE
Scrub missing paths from coverage

### DIFF
--- a/tasks/gotest/scrub_test.go
+++ b/tasks/gotest/scrub_test.go
@@ -1,0 +1,111 @@
+package gotest
+
+import (
+	"testing"
+
+	"github.com/anchore/go-make/require"
+)
+
+func Test_scrubCoverLines(t *testing.T) {
+	const modPath = "github.com/example/mod"
+
+	// present holds the rel paths the fake fileExists should report as existing.
+	tests := []struct {
+		name        string
+		present     []string
+		lines       []string
+		wantKept    []string
+		wantDropped []string
+	}{
+		{
+			name:    "preserves header, blanks, and existing in-module rows",
+			present: []string{"foo/foo.go"},
+			lines: []string{
+				"mode: atomic",
+				"github.com/example/mod/foo/foo.go:1.1,2.2 1 1",
+				"",
+			},
+			wantKept: []string{
+				"mode: atomic",
+				"github.com/example/mod/foo/foo.go:1.1,2.2 1 1",
+				"",
+			},
+		},
+		{
+			name:    "drops in-module rows whose file is missing",
+			present: []string{"foo/foo.go"},
+			lines: []string{
+				"mode: atomic",
+				"github.com/example/mod/foo/foo.go:1.1,2.2 1 1",
+				"github.com/example/mod/bar/gone.go:1.1,2.2 1 0",
+			},
+			wantKept: []string{
+				"mode: atomic",
+				"github.com/example/mod/foo/foo.go:1.1,2.2 1 1",
+			},
+			wantDropped: []string{"github.com/example/mod/bar/gone.go"},
+		},
+		{
+			name: "passes through rows outside the module",
+			lines: []string{
+				"mode: atomic",
+				"github.com/other/mod/x.go:1.1,2.2 1 1",
+			},
+			wantKept: []string{
+				"mode: atomic",
+				"github.com/other/mod/x.go:1.1,2.2 1 1",
+			},
+		},
+		{
+			name: "keeps malformed rows with no colon",
+			lines: []string{
+				"mode: atomic",
+				"this-row-has-no-colon",
+			},
+			wantKept: []string{
+				"mode: atomic",
+				"this-row-has-no-colon",
+			},
+		},
+		{
+			name: "drops every row for a missing file and preserves input order",
+			lines: []string{
+				"mode: atomic",
+				"github.com/example/mod/bar/gone.go:1.1,2.2 1 0",
+				"github.com/example/mod/bar/gone.go:3.1,4.2 1 0",
+				"github.com/example/mod/bar/gone.go:5.1,6.2 1 0",
+			},
+			wantKept: []string{
+				"mode: atomic",
+			},
+			// only one entry in dropped — memoized after the first miss.
+			wantDropped: []string{"github.com/example/mod/bar/gone.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			present := map[string]bool{}
+			for _, p := range tt.present {
+				present[p] = true
+			}
+			calls := map[string]int{}
+			fileExists := func(rel string) bool {
+				calls[rel]++
+				return present[rel]
+			}
+
+			gotKept, gotDropped := scrubCoverLines(tt.lines, modPath, fileExists)
+
+			require.Equal(t, tt.wantKept, gotKept)
+			require.Equal(t, tt.wantDropped, gotDropped)
+
+			// memoization: every checked file should be stat'd at most once.
+			for rel, n := range calls {
+				if n > 1 {
+					t.Fatalf("fileExists(%q) called %d times; expected memoization", rel, n)
+				}
+			}
+		})
+	}
+}

--- a/tasks/gotest/test.go
+++ b/tasks/gotest/test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/anchore/go-make/config"
 	"github.com/anchore/go-make/file"
 	"github.com/anchore/go-make/github"
+	"github.com/anchore/go-make/gomod"
 	"github.com/anchore/go-make/lang"
 	"github.com/anchore/go-make/log"
 	"github.com/anchore/go-make/run"
@@ -82,6 +83,9 @@ func Tasks(options ...Option) Task {
 			Log("Done running %s tests in %v", cfg.Name, time.Since(start))
 
 			if coverageFile != "" && cfg.CoverageFile == "" {
+				// drop entries for files that no longer exist (e.g. renamed/deleted between cached
+				// test runs and now) so `go tool cover -func` doesn't fail trying to open them.
+				scrubMissingFilesFromCoverProfile(coverageFile)
 				report := Run("go tool cover", run.Args("-func", coverageFile), run.Quiet())
 				if cfg.Verbose {
 					Log(" -------------- Coverage Report -------------- ")
@@ -196,6 +200,84 @@ func RunFilter(filter string) Option {
 	return func(c *Config) {
 		c.RunFilter = filter
 	}
+}
+
+// scrubMissingFilesFromCoverProfile rewrites the given cover profile to remove rows that point
+// at source files which no longer exist on disk. This happens with `-coverpkg=./...` plus the
+// Go test cache: cached test results from packages that didn't change still replay coverage
+// data for files (in other packages) that have since been renamed or deleted. `go tool cover
+// -func` would otherwise fail with "open ...: no such file or directory" on those entries.
+func scrubMissingFilesFromCoverProfile(coverageFile string) {
+	mod := gomod.Read()
+	if mod == nil || mod.Module == nil {
+		return
+	}
+	modPath := mod.Module.Mod.Path
+	modFile := file.FindParent(file.Cwd(), "go.mod")
+	if modFile == "" {
+		return
+	}
+	modRoot := filepath.Dir(modFile)
+
+	contents, err := os.ReadFile(coverageFile)
+	if err != nil {
+		log.Debug("unable to read cover profile for scrubbing: %v", err)
+		return
+	}
+
+	fileExists := func(rel string) bool {
+		_, statErr := os.Stat(filepath.Join(modRoot, rel)) //nolint:gosec // G703: path derived from in-module cover profile rows
+		return statErr == nil
+	}
+
+	kept, dropped := scrubCoverLines(strings.Split(string(contents), "\n"), modPath, fileExists)
+	if len(dropped) == 0 {
+		return
+	}
+
+	for _, p := range dropped {
+		log.Debug("dropping stale cover profile entries for missing file: %s", p)
+	}
+
+	if err := os.WriteFile(coverageFile, []byte(strings.Join(kept, "\n")), 0o600); err != nil {
+		log.Debug("unable to rewrite scrubbed cover profile: %v", err)
+	}
+}
+
+// scrubCoverLines filters cover profile lines, dropping any in-module rows whose source file
+// is reported missing by fileExists. Non-module rows, the mode header, blanks, and anything
+// unparseable are kept as-is. Existence checks are memoized per source path.
+func scrubCoverLines(lines []string, modPath string, fileExists func(rel string) bool) (kept, dropped []string) {
+	exists := map[string]bool{}
+	kept = make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			kept = append(kept, line)
+			continue
+		}
+		colon := strings.Index(line, ":")
+		if colon < 0 {
+			kept = append(kept, line)
+			continue
+		}
+		srcPath := line[:colon]
+		if !strings.HasPrefix(srcPath, modPath+"/") {
+			kept = append(kept, line)
+			continue
+		}
+		ok, seen := exists[srcPath]
+		if !seen {
+			ok = fileExists(strings.TrimPrefix(srcPath, modPath+"/"))
+			exists[srcPath] = ok
+			if !ok {
+				dropped = append(dropped, srcPath)
+			}
+		}
+		if ok {
+			kept = append(kept, line)
+		}
+	}
+	return kept, dropped
 }
 
 func selectPackages(include, exclude string) []string {


### PR DESCRIPTION
`make unit` will fail when a file has been removed after a previous coverage has the path already cached:
```
make unit
[unit] $ go test ./... -coverprofile /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/cover-dir-1955922281/cover.out -covermode=atomic -coverpkg=./... -tags=coverage
ok      github.com/anchore/go-make      0.739s  coverage: 11.9% of statements in ./...
ok      github.com/anchore/go-make/binny        (cached)        coverage: 20.0% of statements in ./...
        github.com/anchore/go-make/tasks/golint         coverage: 0.0% of statements
        github.com/anchore/go-make/tasks/goreleaser             coverage: 0.0% of statements
        github.com/anchore/go-make/tasks/gotask         coverage: 0.0% of statements
ok      github.com/anchore/go-make/tasks/gotest (cached)        coverage: 6.7% of statements in ./...
        github.com/anchore/go-make/tasks/release                coverage: 0.0% of statements
        github.com/anchore/go-make/template             coverage: 0.0% of statements
[unit] Done running unit tests in 1.867822791s



 ERROR: error executing: '/Users/wagoodman/.local/share/mise/installs/go/1.26.2/bin/go tool cover -func /var/folders/c0/4y79v5k56bz8v34chcmvq2k80000gp/T/cover-dir-1955922281/cover.out': exit status 2


STDOUT:
github.com/anchore/go-make/binny/binny.go:45:                                   DefaultConfig                   100.0%
github.com/anchore/go-make/binny/binny.go:50:                                   IsManagedTool                   0.0%
github.com/anchore/go-make/binny/binny.go:56:                                   ManagedToolPath                 0.0%
...
github.com/anchore/go-make/tasks/release/release.go:64:                         ensureNoGoreleaserConfig        0.0%

STDERR:
cover: open /Users/wagoodman/code/go-make/tasks/release/tag_and_create_gh_release.go: no such file or directory



github.com/anchore/go-make/tasks/gotest.Tasks.func1()
/Users/wagoodman/code/go-make/tasks/gotest/test.go:85 +0x890

exit status 2
make: *** [unit] Error 1
```

Note:
```
$ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        renamed:    tasks/release/tag_and_create_gh_release.go -> tasks/release/release.go

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   .make/main.go
        modified:   tasks/goreleaser/release.go
        modified:   tasks/release/release.go
```

The fix is to scrub these missing paths, which will mess with the coverage number a bit, but is more accurate than failing.