### PR TITLE
Add goreleaser to binny config

### DIFF
--- a/.binny.yaml
+++ b/.binny.yaml
@@ -55,6 +55,14 @@ tools:
     with:
       repo: golangci/golangci-lint
 
+  # used to release all artifacts
+  - name: goreleaser
+    version:
+      want: v2.15.2
+    method: github-release
+    with:
+      repo: goreleaser/goreleaser
+
   # used for organizing imports during static analysis
   - name: gosimports
     version:


### PR DESCRIPTION
This is for the benefit of downstream tooling not needing to configure this.