### PR TITLE
Add cosign as release dependency

### DIFF
--- a/tasks/goreleaser/release.go
+++ b/tasks/goreleaser/release.go
@@ -42,10 +42,10 @@ func ReleaseTask() Task {
 
 			Run(`goreleaser release --clean --release-notes`, run.Args(changelogFile))
 		},
-		Tasks: []Task{quillInstallTask(), syftInstallTask(), {
+		Tasks: []Task{quillInstallTask(), syftInstallTask(), cosignInstallTask(), {
 			Name:         "release:dependencies",
 			Description:  "ensure all release dependencies are installed",
-			Dependencies: Deps("dependencies:quill", "dependencies:syft"),
+			Dependencies: Deps("dependencies:quill", "dependencies:syft", "dependencies:cosign"),
 		}},
 	}
 }
@@ -66,6 +66,17 @@ func syftInstallTask() Task {
 		Name: "dependencies:syft",
 		Run: func() {
 			if binny.IsManagedTool("syft") {
+				binny.Install("syft")
+			}
+		},
+	}
+}
+
+func cosignInstallTask() Task {
+	return Task{
+		Name: "dependencies:cosign",
+		Run: func() {
+			if binny.IsManagedTool("cosign") {
 				binny.Install("syft")
 			}
 		},


### PR DESCRIPTION
Some releases depend on using cosign at the `signs` step for goreleaser, this ensure that, if configured with binny, will pull it in as a dependency before calling `goreleaser`.