### PR TITLE
fix goreleaser release dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ bin/
 .idea/
 .server/
 .history/
+.zed/
 
 # test related
 *.fingerprint

--- a/tasks/goreleaser/release.go
+++ b/tasks/goreleaser/release.go
@@ -1,6 +1,8 @@
 package goreleaser
 
 import (
+	"fmt"
+
 	. "github.com/anchore/go-make"
 	"github.com/anchore/go-make/binny"
 	"github.com/anchore/go-make/file"
@@ -42,43 +44,30 @@ func ReleaseTask() Task {
 
 			Run(`goreleaser release --clean --release-notes`, run.Args(changelogFile))
 		},
-		Tasks: []Task{quillInstallTask(), syftInstallTask(), cosignInstallTask(), {
-			Name:         "release:dependencies",
-			Description:  "ensure all release dependencies are installed",
-			Dependencies: Deps("dependencies:quill", "dependencies:syft", "dependencies:cosign"),
-		}},
+		Tasks: releaseDependencyTasks("quill", "syft", "cosign"),
 	}
 }
 
-func quillInstallTask() Task {
-	return Task{
-		Name: "dependencies:quill",
-		Run: func() {
-			if binny.IsManagedTool("quill") {
-				binny.Install("quill")
-			}
-		},
+func releaseDependencyTasks(names ...string) []Task {
+	tasks := make([]Task, len(names))
+	taskNames := make([]string, len(names))
+	for i, name := range names {
+		taskNames[i] = fmt.Sprintf("dependencies:%s", name)
+		tasks[i] = Task{
+			Name: taskNames[i],
+			Run: func() {
+				if binny.IsManagedTool(name) {
+					binny.Install(name)
+				}
+			},
+		}
 	}
-}
 
-func syftInstallTask() Task {
-	return Task{
-		Name: "dependencies:syft",
-		Run: func() {
-			if binny.IsManagedTool("syft") {
-				binny.Install("syft")
-			}
-		},
-	}
-}
+	tasks = append(tasks, Task{
+		Name:         "release:dependencies",
+		Description:  "ensure all release dependencies are installed",
+		Dependencies: Deps(taskNames...),
+	})
 
-func cosignInstallTask() Task {
-	return Task{
-		Name: "dependencies:cosign",
-		Run: func() {
-			if binny.IsManagedTool("cosign") {
-				binny.Install("syft")
-			}
-		},
-	}
+	return tasks
 }

--- a/tasks/goreleaser/release_test.go
+++ b/tasks/goreleaser/release_test.go
@@ -1,0 +1,66 @@
+package goreleaser
+
+import (
+	"testing"
+
+	"github.com/anchore/go-make/require"
+)
+
+func Test_releaseDependencyTasks(t *testing.T) {
+	tests := []struct {
+		name      string
+		toolNames []string
+		wantNames []string
+		wantDeps  []string
+	}{
+		{
+			name:      "single tool",
+			toolNames: []string{"quill"},
+			wantNames: []string{"dependencies:quill", "release:dependencies"},
+			wantDeps:  []string{"dependencies:quill"},
+		},
+		{
+			name:      "multiple tools",
+			toolNames: []string{"quill", "syft", "cosign"},
+			wantNames: []string{"dependencies:quill", "dependencies:syft", "dependencies:cosign", "release:dependencies"},
+			wantDeps:  []string{"dependencies:quill", "dependencies:syft", "dependencies:cosign"},
+		},
+		{
+			name:      "no tools",
+			toolNames: nil,
+			wantNames: []string{"release:dependencies"},
+			wantDeps:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := releaseDependencyTasks(tt.toolNames...)
+
+			// shape: one task per name + aggregate
+			require.Equal(t, len(tt.toolNames)+1, len(tasks))
+
+			gotNames := make([]string, len(tasks))
+			for i, tsk := range tasks {
+				gotNames[i] = tsk.Name
+			}
+			require.EqualElements(t, tt.wantNames, gotNames)
+
+			// per-tool install tasks must have a Run set (otherwise depending on them is a no-op)
+			for i := range tt.toolNames {
+				if tasks[i].Run == nil {
+					t.Fatalf("task %q expected non-nil Run", tasks[i].Name)
+				}
+			}
+
+			// aggregate task is appended last
+			aggregate := tasks[len(tasks)-1]
+			require.Equal(t, "release:dependencies", aggregate.Name)
+			require.NotEmpty(t, aggregate.Description)
+			if aggregate.Run != nil {
+				t.Fatalf("aggregate task should be a label (no Run)")
+			}
+			require.EqualElements(t, tt.wantDeps, aggregate.Dependencies)
+		})
+	}
+}


### PR DESCRIPTION
#95 did not correctly update all copy-pasted values, this updates the value and makes such issue a little harder to do in the future.