### PR TITLE
Add coverage thresholds

### DIFF
--- a/tasks/gotest/coverage_test.go
+++ b/tasks/gotest/coverage_test.go
@@ -1,0 +1,149 @@
+package gotest
+
+import (
+	"testing"
+
+	"github.com/anchore/go-make/require"
+)
+
+func Test_parseCoveragePercent(t *testing.T) {
+	tests := []struct {
+		name      string
+		report    string
+		wantRaw   string
+		wantPct   float64
+		wantFound bool
+	}{
+		{
+			name: "parses total coverage from go tool cover output",
+			report: "github.com/foo/bar/baz.go:10:		Foo	100.0%\n" +
+				"total:					(statements)	73.4%\n",
+			wantRaw:   "73.4",
+			wantPct:   73.4,
+			wantFound: true,
+		},
+		{
+			name:      "handles zero coverage",
+			report:    "total:		(statements)	0.0%\n",
+			wantRaw:   "0.0",
+			wantPct:   0.0,
+			wantFound: true,
+		},
+		{
+			name:      "handles full coverage",
+			report:    "total:		(statements)	100.0%\n",
+			wantRaw:   "100.0",
+			wantPct:   100.0,
+			wantFound: true,
+		},
+		{
+			name:      "preserves multi-decimal precision in raw output",
+			report:    "total:		(statements)	79.95%\n",
+			wantRaw:   "79.95",
+			wantPct:   79.95,
+			wantFound: true,
+		},
+		{
+			name:      "returns false when no total line present",
+			report:    "github.com/foo/bar/baz.go:10:	Foo	100.0%\n",
+			wantFound: false,
+		},
+		{
+			name:      "returns false on empty input",
+			report:    "",
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, pct, found := parseCoveragePercent(tt.report)
+			require.Equal(t, tt.wantFound, found)
+			if !found {
+				return
+			}
+			require.Equal(t, tt.wantRaw, raw)
+			require.Equal(t, tt.wantPct, pct)
+		})
+	}
+}
+
+func Test_enforceCoverageThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawPct    string
+		coverage  float64
+		found     bool
+		threshold float64
+		wantErr   string
+	}{
+		{
+			name:      "no threshold means no error even if unparseable",
+			found:     false,
+			threshold: 0,
+		},
+		{
+			name:      "negative threshold disables the check",
+			rawPct:    "10.0",
+			coverage:  10,
+			found:     true,
+			threshold: -1,
+		},
+		{
+			name:      "coverage equal to threshold passes",
+			rawPct:    "80.0",
+			coverage:  80.0,
+			found:     true,
+			threshold: 80.0,
+		},
+		{
+			name:      "coverage above threshold passes",
+			rawPct:    "85.5",
+			coverage:  85.5,
+			found:     true,
+			threshold: 80.0,
+		},
+		{
+			name:      "coverage below threshold fails",
+			rawPct:    "79.9",
+			coverage:  79.9,
+			found:     true,
+			threshold: 80.0,
+			wantErr:   "coverage 79.9% is below threshold 80%",
+		},
+		{
+			name:      "uses raw string to avoid rounding ambiguity",
+			rawPct:    "79.96",
+			coverage:  79.96,
+			found:     true,
+			threshold: 80.0,
+			wantErr:   "coverage 79.96% is below threshold 80%",
+		},
+		{
+			name:      "fractional threshold renders without trailing zero",
+			rawPct:    "80.0",
+			coverage:  80.0,
+			found:     true,
+			threshold: 80.5,
+			wantErr:   "coverage 80.0% is below threshold 80.5%",
+		},
+		{
+			name:      "threshold set but coverage unparseable fails",
+			found:     false,
+			threshold: 80.0,
+			wantErr:   "coverage threshold 80% set but coverage percentage could not be determined",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := enforceCoverageThreshold(tt.rawPct, tt.coverage, tt.found, tt.threshold)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}

--- a/tasks/gotest/test.go
+++ b/tasks/gotest/test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +20,9 @@ import (
 	"github.com/anchore/go-make/log"
 	"github.com/anchore/go-make/run"
 )
+
+// coverageTotalRE matches the "total:" line emitted by `go tool cover -func`.
+var coverageTotalRE = regexp.MustCompile(`total:[^\n%]+?(\d+\.\d+)%`)
 
 // Tasks creates a test task that runs Go tests with coverage reporting.
 // The task hooks into the "test" label, so it runs whenever "make test" is called.
@@ -36,86 +40,136 @@ func Tasks(options ...Option) Task {
 		opt(&cfg)
 	}
 
+	// fail fast at task construction so misconfiguration surfaces before any tests run.
+	if cfg.CoverageThreshold > 0 && !cfg.Coverage {
+		lang.Throw(fmt.Errorf("coverage threshold requires coverage to be enabled"))
+	}
+
 	return Task{
 		Name:        cfg.Name,
 		Description: fmt.Sprintf("run %s tests", cfg.Name),
 		RunsOn:      Deps("test"),
-		Run: func() {
-			start := time.Now()
-			args := Deps("test")
-			if cfg.Verbose {
-				args = append(args, "-v")
-			}
-			if cfg.RunFilter != "" {
-				args = append(args, "-run", cfg.RunFilter)
-			}
-			args = append(args, selectPackages(cfg.IncludeGlob, cfg.ExcludeGlob)...)
+		Run:         func() { runTests(&cfg) },
+	}
+}
 
-			coverageFile := cfg.CoverageFile
-			if cfg.Coverage {
-				if coverageFile == "" {
-					coverageDir, err := os.MkdirTemp(config.TmpDir, "cover-dir-")
-					if err == nil {
-						defer func() {
-							log.Error(os.RemoveAll(coverageDir))
-						}()
-						coverageDir, err = filepath.Abs(coverageDir)
-						if err == nil {
-							coverageFile = filepath.Join(coverageDir, "cover.out")
-						}
-					}
-				}
-				args = append(args, "-coverprofile", coverageFile)
-				args = append(args, "-covermode=atomic", "-coverpkg=./...")
-				// add coverage tag to existing tags
-				cfg.Tags = append(cfg.Tags, "coverage")
-			}
-			if len(cfg.Tags) > 0 {
-				args = append(args, "-tags="+strings.Join(cfg.Tags, ","))
-			}
+func runTests(cfg *Config) {
+	start := time.Now()
 
-			if cfg.Race {
-				args = append(args, "-race")
-			}
+	coverageFile, cleanup := resolveCoverageFile(cfg)
+	defer cleanup()
 
-			Run("go", run.Args(args...), run.Stdout(os.Stderr), run.Env("GODEBUG", "dontfreezetheworld=1"))
+	args := buildTestArgs(cfg, coverageFile)
+	Run("go", run.Args(args...), run.Stdout(os.Stderr), run.Env("GODEBUG", "dontfreezetheworld=1"))
+	Log("Done running %s tests in %v", cfg.Name, time.Since(start))
 
-			Log("Done running %s tests in %v", cfg.Name, time.Since(start))
+	if coverageFile == "" {
+		return
+	}
+	processCoverage(cfg, coverageFile)
+	uploadCoverage(coverageFile)
+}
 
-			if coverageFile != "" && cfg.CoverageFile == "" {
-				// drop entries for files that no longer exist (e.g. renamed/deleted between cached
-				// test runs and now) so `go tool cover -func` doesn't fail trying to open them.
-				scrubMissingFilesFromCoverProfile(coverageFile)
-				report := Run("go tool cover", run.Args("-func", coverageFile), run.Quiet())
-				if cfg.Verbose {
-					Log(" -------------- Coverage Report -------------- ")
-					Log(report)
-				} else {
-					coverage := regexp.MustCompile(`total:[^\n%]+?(\d+\.\d+)%`).FindStringSubmatch(report)
-					if len(coverage) > 1 {
-						Log("Coverage: %s%%", coverage[1])
-					} else {
-						Log(" -------------- Coverage Report -------------- ")
-						log.Error(fmt.Errorf("unable to find coverage percentage in report"))
-						Log(report)
-					}
-				}
-			}
+// buildTestArgs assembles the `go test` argument list. coverageFile is the resolved
+// cover profile path (may be empty when coverage is disabled or temp-dir creation failed).
+func buildTestArgs(cfg *Config, coverageFile string) []string {
+	args := Deps("test")
+	if cfg.Verbose {
+		args = append(args, "-v")
+	}
+	if cfg.RunFilter != "" {
+		args = append(args, "-run", cfg.RunFilter)
+	}
+	args = append(args, selectPackages(cfg.IncludeGlob, cfg.ExcludeGlob)...)
 
-			if coverageFile != "" && config.OS == "linux" {
-				err := lang.Catch(func() {
-					dir := filepath.Dir(coverageFile)
-					lang.Return(github.NewClient().UploadArtifactDir(dir, github.UploadArtifactOption{
-						ArtifactName: "code-coverage",
-						Overwrite:    false, // we only need one, failures are logged but ignored
-						Files:        []string{coverageFile},
-					}))
-				})
-				if err != nil {
-					log.Debug("error uploading coverage file: %v", err)
-				}
-			}
-		},
+	tags := cfg.Tags
+	if cfg.Coverage {
+		args = append(args, "-coverprofile", coverageFile)
+		args = append(args, "-covermode=atomic", "-coverpkg=./...")
+		tags = append(tags, "coverage")
+	}
+	if len(tags) > 0 {
+		args = append(args, "-tags="+strings.Join(tags, ","))
+	}
+	if cfg.Race {
+		args = append(args, "-race")
+	}
+	return args
+}
+
+// resolveCoverageFile returns the coverage file path and a cleanup func. When the caller
+// did not supply a path, a temp dir is created and its removal is deferred via the returned
+// func. Returns empty string when coverage is disabled.
+func resolveCoverageFile(cfg *Config) (string, func()) {
+	noop := func() {}
+	if !cfg.Coverage {
+		return "", noop
+	}
+	if cfg.CoverageFile != "" {
+		return cfg.CoverageFile, noop
+	}
+	coverageDir, err := os.MkdirTemp(config.TmpDir, "cover-dir-")
+	if err != nil {
+		return "", noop
+	}
+	cleanup := func() { log.Error(os.RemoveAll(coverageDir)) }
+	absDir, err := filepath.Abs(coverageDir)
+	if err != nil {
+		return "", cleanup
+	}
+	return filepath.Join(absDir, "cover.out"), cleanup
+}
+
+// processCoverage runs `go tool cover -func`, logs the report, and enforces any threshold.
+func processCoverage(cfg *Config, coverageFile string) {
+	if cfg.CoverageFile == "" {
+		// only scrub the cover profile when we own the file (temp dir). When the caller
+		// supplied an explicit path, leave their file untouched. Drops entries for files
+		// that no longer exist (e.g. renamed/deleted between cached test runs and now)
+		// so `go tool cover -func` doesn't fail trying to open them.
+		scrubMissingFilesFromCoverProfile(coverageFile)
+	}
+	report := Run("go tool cover", run.Args("-func", coverageFile), run.Quiet())
+	rawPct, coverage, found := parseCoveragePercent(report)
+	logCoverageReport(report, rawPct, found, cfg.Verbose)
+
+	if err := enforceCoverageThreshold(rawPct, coverage, found, cfg.CoverageThreshold); err != nil {
+		lang.Throw(err)
+	}
+}
+
+func logCoverageReport(report, rawPct string, found, verbose bool) {
+	switch {
+	case found && verbose:
+		Log(" -------------- Coverage Report -------------- ")
+		Log(report)
+	case found:
+		Log("Coverage: %s%%", rawPct)
+	default:
+		// parse failures always log the report and an error, regardless of verbose,
+		// so the user can see what went wrong.
+		Log(" -------------- Coverage Report -------------- ")
+		Log(report)
+		log.Error(fmt.Errorf("unable to find coverage percentage in report"))
+	}
+}
+
+// uploadCoverage best-effort uploads the cover profile as a GitHub Actions artifact on linux.
+// Errors are intentionally swallowed (logged at debug) so they don't fail the task.
+func uploadCoverage(coverageFile string) {
+	if config.OS != "linux" {
+		return
+	}
+	err := lang.Catch(func() {
+		dir := filepath.Dir(coverageFile)
+		lang.Return(github.NewClient().UploadArtifactDir(dir, github.UploadArtifactOption{
+			ArtifactName: "code-coverage",
+			Overwrite:    false, // we only need one, failures are logged but ignored
+			Files:        []string{coverageFile},
+		}))
+	})
+	if err != nil {
+		log.Debug("error uploading coverage file: %v", err)
 	}
 }
 
@@ -133,6 +187,11 @@ type Config struct {
 	Coverage bool
 	// CoverageFile specifies where to write coverage data. If empty, uses temp file.
 	CoverageFile string
+	// CoverageThreshold is the minimum total coverage percentage required to pass.
+	// If > 0, the task fails when measured coverage falls below this value, or
+	// when the coverage percentage cannot be parsed from the report. Requires
+	// Coverage to be enabled.
+	CoverageThreshold float64
 	// Race enables race detector (-race flag). Defaults to true in CI on non-Windows.
 	Race bool
 	// Tags specifies build tags to use during testing.
@@ -186,6 +245,46 @@ func NoCoverage() Option {
 	return func(c *Config) {
 		c.Coverage = false
 	}
+}
+
+// CoverageThreshold sets the minimum total coverage percentage required to pass.
+// Values <= 0 disable the check. If measured coverage falls below this value,
+// the task fails. Example: gotest.CoverageThreshold(80) requires at least 80%.
+func CoverageThreshold(percent float64) Option {
+	return func(c *Config) {
+		c.CoverageThreshold = percent
+	}
+}
+
+// parseCoveragePercent extracts the "total: ... NN.N%" coverage percentage from
+// the output of `go tool cover -func`. Returns the raw matched string (for
+// display, to avoid rounding the value the tool emitted), the parsed float, and
+// true on success. The regex's `(\d+\.\d+)` capture guarantees a valid float, so
+// strconv.ParseFloat cannot fail on a successful match.
+func parseCoveragePercent(report string) (string, float64, bool) {
+	match := coverageTotalRE.FindStringSubmatch(report)
+	if len(match) < 2 {
+		return "", 0, false
+	}
+	pct, _ := strconv.ParseFloat(match[1], 64)
+	return match[1], pct, true
+}
+
+// enforceCoverageThreshold returns an error if the threshold is set (> 0) and
+// either the coverage value could not be parsed or it falls below the threshold.
+// A non-positive threshold disables the check. rawPct is the tool-emitted string
+// (used for display so we don't round the value the user is reading).
+func enforceCoverageThreshold(rawPct string, coverage float64, found bool, threshold float64) error {
+	if threshold <= 0 {
+		return nil
+	}
+	if !found {
+		return fmt.Errorf("coverage threshold %g%% set but coverage percentage could not be determined", threshold)
+	}
+	if coverage < threshold {
+		return fmt.Errorf("coverage %s%% is below threshold %g%%", rawPct, threshold)
+	}
+	return nil
 }
 
 // Tags adds build tags to use during testing.

--- a/tasks/gotest/test.go
+++ b/tasks/gotest/test.go
@@ -157,7 +157,7 @@ func logCoverageReport(report, rawPct string, found, verbose bool) {
 // uploadCoverage best-effort uploads the cover profile as a GitHub Actions artifact on linux.
 // Errors are intentionally swallowed (logged at debug) so they don't fail the task.
 func uploadCoverage(coverageFile string) {
-	if config.OS != "linux" {
+	if !config.CI || config.OS != "linux" {
 		return
 	}
 	err := lang.Catch(func() {

--- a/tasks/gotest/test_test.go
+++ b/tasks/gotest/test_test.go
@@ -25,4 +25,7 @@ func Test_Task(t *testing.T) {
 
 	gotest.ExcludeGlob("**/*skip*")(&cfg)
 	require.Equal(t, "**/*skip*", cfg.ExcludeGlob)
+
+	gotest.CoverageThreshold(75.5)(&cfg)
+	require.Equal(t, 75.5, cfg.CoverageThreshold)
 }


### PR DESCRIPTION
This expands on the coverage for unit tests to not only be able to show coverage but also set a threshold to require a min % code coverage on unit tests:
```
gotest.Tasks(gotest.CoverageThreshold(80)) # optional 
```