### PR TITLE
fix index-out-of-range in binny version matching

### DIFF
--- a/binny/binny.go
+++ b/binny/binny.go
@@ -236,13 +236,6 @@ func matchesVersion(versionRequest, versionToCheck string) bool {
 		*ptr = strings.TrimSpace(*ptr)
 		*ptr = strings.TrimPrefix(*ptr, "v")
 	}
-	// "current" is a sentinel meaning "whatever is locally checked out / installed".
-	// There's no version string we could parse from a binary that would meaningfully
-	// match it, so trust the installed binary rather than triggering a reinstall (the
-	// download path can't fetch a "current" release anyway).
-	if versionToCheck == "current" {
-		return true
-	}
 	remover := regexp.MustCompile(`^[-._]`)
 	splitter := regexp.MustCompile(`((^|[-._+~a-zA-Z])[a-zA-Z]*\d+)`)
 	parts1 := splitter.FindAllString(versionRequest, -1)

--- a/binny/binny.go
+++ b/binny/binny.go
@@ -236,13 +236,26 @@ func matchesVersion(versionRequest, versionToCheck string) bool {
 		*ptr = strings.TrimSpace(*ptr)
 		*ptr = strings.TrimPrefix(*ptr, "v")
 	}
+	// "current" is a sentinel meaning "whatever is locally checked out / installed".
+	// There's no version string we could parse from a binary that would meaningfully
+	// match it, so trust the installed binary rather than triggering a reinstall (the
+	// download path can't fetch a "current" release anyway).
+	if versionToCheck == "current" {
+		return true
+	}
 	remover := regexp.MustCompile(`^[-._]`)
 	splitter := regexp.MustCompile(`((^|[-._+~a-zA-Z])[a-zA-Z]*\d+)`)
 	parts1 := splitter.FindAllString(versionRequest, -1)
 	parts2 := splitter.FindAllString(versionToCheck, -1)
+	// when either side has no digit-bearing tokens (e.g. "main", "feature-x"), the
+	// component-wise comparison below has nothing to align against; fall back to a
+	// direct string comparison so non-numeric refs still produce sensible results.
+	if len(parts1) == 0 || len(parts2) == 0 {
+		return versionRequest == versionToCheck
+	}
 	for i, part := range parts1 {
 		part = remover.ReplaceAllString(part, "")
-		if i <= len(parts2) {
+		if i < len(parts2) {
 			part2 := remover.ReplaceAllString(parts2[i], "")
 			int1, err := strconv.Atoi(part)
 			if err == nil {

--- a/binny/binny_test.go
+++ b/binny/binny_test.go
@@ -122,6 +122,33 @@ func Test_matchesVersion(t *testing.T) {
 			version2: "v0.9.0-rc.2",
 			want:     false,
 		},
+		{
+			// "current" is a sentinel meaning the locally-checked-out source; it
+			// can't be compared against a numeric --version, so treat as matching
+			// to avoid clobbering the local binary with a downloaded release.
+			version1: "v0.13.0",
+			version2: "current",
+			want:     true,
+		},
+		{
+			// regression: previously panicked with index out of range because
+			// "main" produces zero digit-bearing tokens while "0.13.0" produces
+			// three, and the loop accessed parts2[0] anyway.
+			version1: "v0.13.0",
+			version2: "main",
+			want:     false,
+		},
+		{
+			// non-numeric refs on both sides fall back to direct string equality.
+			version1: "main",
+			version2: "main",
+			want:     true,
+		},
+		{
+			version1: "feature-x",
+			version2: "feature-y",
+			want:     false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/binny/binny_test.go
+++ b/binny/binny_test.go
@@ -78,56 +78,50 @@ func Test_matchesVersion(t *testing.T) {
 		want     bool
 	}{
 		{
+			// baseline: leading "v" is optional on either side.
 			version1: "0.9.0",
 			version2: "v0.9.0",
 			want:     true,
 		},
 		{
-			version1: "v0.9.0",
-			version2: "0.9.0",
-			want:     true,
-		},
-		{
+			// baseline: surrounding whitespace is trimmed before comparison.
 			version1: " v0.9.0 ",
 			version2: "0.9.0",
 			want:     true,
 		},
 		{
+			// baseline: a differing numeric component is a mismatch.
 			version1: "v0.8.0",
 			version2: "v0.9.0",
 			want:     false,
 		},
 		{
-			version1: "v0.9.0",
-			version2: "v0.8.0",
-			want:     false,
-		},
-		{
-			version1: "0.9.0",
-			version2: "v0.8.0",
-			want:     false,
-		},
-		{
+			// baseline: when parts1 has fewer tokens than parts2, the extras
+			// in parts2 are ignored — a less-specific request matches a
+			// more-specific installed version as long as the shared prefix agrees.
 			version1: "v0.9",
 			version2: "v0.9.0",
 			want:     true,
 		},
 		{
+			// baseline: prerelease tokens are compared component-wise; equal here.
 			version1: "v0.9.0-rc.1",
 			version2: "v0.9.0-rc.1",
 			want:     true,
 		},
 		{
+			// baseline: a differing prerelease component is a mismatch.
 			version1: "v0.9.0-rc.1",
 			version2: "v0.9.0-rc.2",
 			want:     false,
 		},
 		{
-			// "current" is a sentinel meaning the locally-checked-out source; it
-			// can't be compared against a numeric --version, so treat as matching
-			// to avoid clobbering the local binary with a downloaded release.
-			version1: "v0.13.0",
-			version2: "current",
+			// regression: parts1 has more digit-bearing tokens than parts2.
+			// Previously panicked because the loop used i <= len(parts2)
+			// instead of i < len(parts2), so at i==len(parts2) it accessed
+			// parts2[len(parts2)] which is out of bounds.
+			version1: "v0.9.0",
+			version2: "v0.9",
 			want:     true,
 		},
 		{
@@ -145,8 +139,12 @@ func Test_matchesVersion(t *testing.T) {
 			want:     true,
 		},
 		{
-			version1: "feature-x",
-			version2: "feature-y",
+			// "current" is not a sentinel: it's treated as any other non-numeric
+			// ref. A configured target of "current" will never match a real
+			// --version output, so it will trigger a reinstall. Pin this so a
+			// future change doesn't quietly re-introduce special handling.
+			version1: "v0.13.0",
+			version2: "current",
 			want:     false,
 		},
 	}

--- a/lang/errors.go
+++ b/lang/errors.go
@@ -172,11 +172,12 @@ func skipTraceLine(line string) bool {
 		return false
 	}
 	line = strings.TrimSpace(line)
+	// keep go-make internal frames (binny, run, template, etc.) so that runtime
+	// panics inside go-make show their actual origin instead of just the user-task
+	// call site. only filter pure noise: the runtime panic machinery, the test
+	// harness, and the main entry.
 	return strings.HasPrefix(line, "panic(") ||
 		strings.HasPrefix(line, "runtime/") ||
 		strings.Contains(line, "testing.") ||
-		strings.HasPrefix(line, "main.main()") ||
-		strings.HasPrefix(line, "github.com/anchore/go-make.") ||
-		(strings.HasPrefix(line, "github.com/anchore/go-make/") &&
-			!strings.HasPrefix(line, "github.com/anchore/go-make/tasks/"))
+		strings.HasPrefix(line, "main.main()")
 }

--- a/lang/errors.go
+++ b/lang/errors.go
@@ -172,12 +172,11 @@ func skipTraceLine(line string) bool {
 		return false
 	}
 	line = strings.TrimSpace(line)
-	// keep go-make internal frames (binny, run, template, etc.) so that runtime
-	// panics inside go-make show their actual origin instead of just the user-task
-	// call site. only filter pure noise: the runtime panic machinery, the test
-	// harness, and the main entry.
 	return strings.HasPrefix(line, "panic(") ||
 		strings.HasPrefix(line, "runtime/") ||
 		strings.Contains(line, "testing.") ||
-		strings.HasPrefix(line, "main.main()")
+		strings.HasPrefix(line, "main.main()") ||
+		strings.HasPrefix(line, "github.com/anchore/go-make.") ||
+		(strings.HasPrefix(line, "github.com/anchore/go-make/") &&
+			!strings.HasPrefix(line, "github.com/anchore/go-make/tasks/"))
 }


### PR DESCRIPTION
When `name: binny / version: { want: current }` was present in `.binny.yaml` then any task would panic:

```
$ make lint-fix
[format] $ gofmt -w -s .

 ERROR: runtime error: index out of range [0] with length 0

github.com/anchore/go-make/tasks/golint.Tasks.FormatTask.func1()
/Users/wagoodman/go/pkg/mod/github.com/anchore/go-make@v0.3.2/tasks/golint/format.go:98 +0x78

exit status 1
```

This PR fixes the panic in `binny.matchesVersion` that fires whenever a local `.binny.yaml` overrides the binny version with a non-numeric value like `want: current` or `want: main`.

Changes:
- off-by-one in `matchesVersion`: `i <= len(parts2)` accessed `parts2[len(parts2)]` when `parts1` had more digit-bearing tokens than `parts2`. Changed to `i < len(parts2)`.
- ~`want: current` is a sentinel meaning "use whatever is locally checked out"... there's no version string parseable from `binny --version` that would match it, and the download/build paths can't fetch a `current` release. Short-circuit it to `true` so the installed binary isn't clobbered.~
- when either side has zero digit-bearing tokens (e.g. branch names like `main`, `feature-x`), fall back to direct string equality instead of entering the comparison loop with an empty `parts2`.

~It was a little hard to debug where this was coming from since `lang.skipTraceLine` was hiding every `github.com/anchore/go-make/...` frame except `tasks/`, which made the original panic surface as just `format.go:98` with no indication that the real failure was inside `binny`. Now only true noise is filtered (`runtime/`, `panic(`, `testing.`, `main.main()`); internal frames stay visible.~