### PR TITLE
Fix argument truncation

### DIFF
--- a/run/run.go
+++ b/run/run.go
@@ -289,16 +289,27 @@ func LDFlags(flags ...string) Option {
 	}
 }
 
+// shortenedArgs trims the args portion of the command line for display when it would
+// otherwise exceed maxDisplayLen characters (e.g. `go test pkg1 pkg2 ... pkgN` with
+// hundreds of packages). It keeps as many leading args as fit within the budget and
+// replaces the rest with a single "... (N more, DEBUG=1 to show)" marker. Set DEBUG=1
+// (or any other mechanism that flips config.Debug) to skip shortening entirely.
 func shortenedArgs(args []string) []string {
-	const maxLen = 16
-	var out []string
-	for _, arg := range args {
-		if len(out) > maxLen && len(arg) > maxLen {
-			arg = arg[:maxLen]
-		}
-		out = append(out, arg)
+	if config.Debug {
+		return args
 	}
-	return out
+	const maxDisplayLen = 200
+	total := 0
+	for i, arg := range args {
+		total += len(arg) + 1 // +1 for the joining space
+		if total > maxDisplayLen && i < len(args)-1 {
+			remaining := len(args) - i - 1
+			// three-index slice forces a new backing array so we don't mutate args.
+			// Grey the marker so it's visually distinct from the actual command args.
+			return append(args[:i+1:i+1], color.Grey("... (%d more, DEBUG=1 to show)", remaining))
+		}
+	}
+	return args
 }
 
 func skipEnvVar(s string) bool {

--- a/run/run_test.go
+++ b/run/run_test.go
@@ -13,6 +13,61 @@ import (
 	"github.com/anchore/go-make/require"
 )
 
+func Test_shortenedArgs(t *testing.T) {
+	longPkg := "github.com/anchore/syft/cmd/syft/internal/commands"
+	manyPkgs := make([]string, 50)
+	for i := range manyPkgs {
+		manyPkgs[i] = longPkg
+	}
+
+	tests := []struct {
+		name      string
+		debug     bool
+		args      []string
+		want      []string // expected output (nil to skip exact match and use truncated assertion instead)
+		truncated bool     // expect shortening + summary marker
+	}{
+		{
+			name: "short command is unchanged",
+			args: []string{"build", "-o", "out", "./cmd/foo"},
+			want: []string{"build", "-o", "out", "./cmd/foo"},
+		},
+		{
+			name: "empty is unchanged",
+			args: nil,
+			want: nil,
+		},
+		{
+			name:  "debug returns full args verbatim",
+			debug: true,
+			args:  append([]string{"test"}, manyPkgs...),
+			want:  append([]string{"test"}, manyPkgs...),
+		},
+		{
+			name:      "long arg list is replaced with summary marker",
+			args:      append([]string{"test"}, manyPkgs...),
+			truncated: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.debug {
+				require.SetAndRestore(t, &config.Debug, true)
+			}
+
+			got := shortenedArgs(tt.args)
+
+			if tt.truncated {
+				require.True(t, len(got) < len(tt.args))
+				require.Contains(t, got[len(got)-1], "more, DEBUG=1 to show")
+				return
+			}
+			require.EqualElements(t, tt.want, got)
+		})
+	}
+}
+
 func Test_Command(t *testing.T) {
 	buf1 := bytes.Buffer{}
 	buf2 := bytes.Buffer{}


### PR DESCRIPTION
In syft, argument truncation is causing the output to look like this:
```
[unit] $ go test github.com/anchore/syft/cmd/syft github.com/anchore/syft/cmd/syft/cli github.com/anchore/syft/cmd/syft/cli/ui github.com/anchore/syft/cmd/syft/internal github.com/anchore/syft/cmd/syft/internal/commands github.com/anchore/syft/cmd/syft/internal/options github.com/anchore/syft/cmd/syft/internal/ui github.com/anchore/syft/examples/create_custom_sbom github.com/anchore/syft/examples/create_simple_sbom github.com/anchore/syft/examples/decode_sbom github.com/anchore/syft/examples/select_catalogers github.com/anchore/syft/examples/source_detection github.com/anchore/syft/examples/source_from_image github.com/anchore/syft/examples/source_from_registry github.com/anchore/syft/internal github.com/anchore/syft/internal/bus github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho github.com/ancho -coverprofile /var/folders/c0/ -covermode=atomi -coverpkg=./... -tags=coverage
```

This is both too verbose and not showing enough information to figure out what's going on.

This changes the output to look like this instead:

```
[unit] $ go test github.com/anchore/syft/cmd/syft github.com/anchore/syft/cmd/syft/cli github.com/anchore/syft/cmd/syft/cli/ui github.com/anchore/syft/cmd/syft/internal github.com/anchore/syft/cmd/syft/internal/commands ... (155 more, DEBUG=1 to show)
	github.com/anchore/syft/cmd/syft		coverage: 0.0% of statements
	github.com/anchore/syft/cmd/syft/cli		coverage: 0.0% of statements
...
```