### PR TITLE
Limit filename lint to non-ignored paths

### DIFF
--- a/tasks/golint/format.go
+++ b/tasks/golint/format.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -149,22 +150,16 @@ func toRunOpts(options []Option) []run.Option {
 }
 
 func findMalformedFilenames(root string) error {
+	paths, err := listCommittablePaths(root)
+	if err != nil {
+		return fmt.Errorf("error walking through files: %w", err)
+	}
+
 	var malformedFilenames []string
-
-	err := filepath.Walk(root, func(path string, _ os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// check if the filename contains the ':' character
+	for _, path := range paths {
 		if strings.Contains(path, ":") {
 			malformedFilenames = append(malformedFilenames, path)
 		}
-		return nil
-	})
-
-	if err != nil {
-		return fmt.Errorf("error walking through files: %w", err)
 	}
 
 	if len(malformedFilenames) > 0 {
@@ -216,4 +211,39 @@ func formatterEnabled(formattersJSON, name string) bool {
 		}
 	}
 	return false
+}
+
+// listCommittablePaths returns the set of paths under root that could plausibly
+// be committed: tracked files plus untracked-but-not-ignored files, as reported
+// by `git ls-files`. Submodules are listed by their directory entry only — their
+// inner files are never walked. Falls back to a plain filesystem walk when root
+// is not inside a git working tree (or git is unavailable).
+func listCommittablePaths(root string) ([]string, error) {
+	if paths, ok := gitListFiles(root); ok {
+		return paths, nil
+	}
+
+	var paths []string
+	err := filepath.Walk(root, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		paths = append(paths, path)
+		return nil
+	})
+	return paths, err
+}
+
+func gitListFiles(root string) ([]string, bool) {
+	cmd := exec.Command("git", "-C", root, "ls-files", "-z", "--cached", "--others", "--exclude-standard")
+	cmd.Stderr = io.Discard
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, false
+	}
+	raw := strings.TrimRight(string(out), "\x00")
+	if raw == "" {
+		return nil, true
+	}
+	return strings.Split(raw, "\x00"), true
 }

--- a/tasks/golint/format_test.go
+++ b/tasks/golint/format_test.go
@@ -1,6 +1,9 @@
 package golint
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/anchore/go-make/require"
@@ -55,5 +58,83 @@ func TestFormatterEnabled(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, formatterEnabled(tt.formattersJSON, tt.formatter))
 		})
+	}
+}
+
+func Test_findMalformedFilenames(t *testing.T) {
+	t.Run("gitignored bad-named file is skipped", func(t *testing.T) {
+		requireGit(t)
+		root := setupGitRoot(t)
+		writeFile(t, root, ".gitignore", "ignored/\n")
+		mkdir(t, root, "ignored")
+		writeFile(t, root, "ignored/bad:name.txt", "")
+
+		require.NoError(t, findMalformedFilenames("."))
+	})
+
+	t.Run("tracked bad-named file fails", func(t *testing.T) {
+		requireGit(t)
+		root := setupGitRoot(t)
+		writeFile(t, root, "bad:name.txt", "")
+		runGit(t, root, "add", "bad:name.txt")
+
+		require.Error(t, findMalformedFilenames("."))
+	})
+
+	t.Run("untracked-but-not-ignored bad-named file fails", func(t *testing.T) {
+		requireGit(t)
+		root := setupGitRoot(t)
+		writeFile(t, root, "bad:name.txt", "")
+
+		require.Error(t, findMalformedFilenames("."))
+	})
+
+	t.Run("no-git fallback walks everything", func(t *testing.T) {
+		root := t.TempDir()
+		t.Chdir(root)
+		writeFile(t, root, "bad:name.txt", "")
+
+		require.Error(t, findMalformedFilenames("."))
+	})
+}
+
+// setupGitRoot creates a temp dir, runs `git init` in it, and chdirs into it.
+// Returns the root so callers can write files via absolute paths.
+func setupGitRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runGit(t, root, "init", "-q")
+	t.Chdir(root)
+	return root
+}
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+func mkdir(t *testing.T, dir, rel string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", p, err)
 	}
 }

--- a/tasks/golint/format_test.go
+++ b/tasks/golint/format_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/anchore/go-make/require"
@@ -62,6 +63,13 @@ func TestFormatterEnabled(t *testing.T) {
 }
 
 func Test_findMalformedFilenames(t *testing.T) {
+	// on Windows ':' is the NTFS alternate-data-stream separator, so
+	// os.WriteFile("bad:name.txt") creates a file named "bad" instead of
+	// failing — the malformed filename these tests rely on cannot exist
+	if runtime.GOOS == "windows" {
+		t.Skip("cannot create filenames containing ':' on Windows")
+	}
+
 	t.Run("gitignored bad-named file is skipped", func(t *testing.T) {
 		requireGit(t)
 		root := setupGitRoot(t)


### PR DESCRIPTION
Previously, if a path under the root dir of a repo using this tool contained a ":", static-analysis would fail even if the path was gitignored or part of a submodule. The submodule case particularly comes up with repos that submodule anchore/vulnerability-match-labels, which has some weird paths, including paths with ":" in them.

Instead, use "git ls-files" to list files that are tracker or untracked but not ignored (and thus might be added and committed) so that this lint still protects the repo from accepting files with ":" in the path but doesn't fail on gitignored scratchwork or surprising decisions by submodules.

For example, in grype today `static-analysis` only passes if the vulnerability-match-labels submodule has not be initialized.

```
$ make static-analysis
... passes ...
$ git submodule update --init test/quality/vulnerability-match-labels
$ make static-analysis
... fails: ...
 ERROR:
error: unsupported filename characters found
```