### PR TITLE
Pin to stable go version

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -9,7 +9,7 @@ description: "Setup go & go-make"
 inputs:
   go-version:
     description: "Go version to install"
-    default: 1.26.2
+    default: stable
   go-version-file:
     description: "Go version file to use"
     default: go.mod
@@ -24,13 +24,15 @@ inputs:
   cache-enabled:
     description: "Enable build/mod and tool caching. When disabled, no restore or save."
     default: "true"
+
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       if: ${{ hashFiles('.git/') == '' }}
       with:
         persist-credentials: false
+
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       if: ${{ inputs.go-version != '' || inputs.go-version-file != '' }}
       with:


### PR DESCRIPTION
This lets us float forward more easily when go releases are available without needing to bump go-make in consuming repos.