### PR TITLE
Add support to wrap taskfile definitions

### DIFF
--- a/tasks/gotask/taskfile.go
+++ b/tasks/gotask/taskfile.go
@@ -1,10 +1,14 @@
 package gotask
 
 import (
-	"encoding/json"
 	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/goccy/go-yaml"
 
 	. "github.com/anchore/go-make"
 	"github.com/anchore/go-make/file"
@@ -13,10 +17,20 @@ import (
 	"github.com/anchore/go-make/run"
 )
 
-// taskInfo is one entry from `task --list-all --json` output.
+// taskInfo is one task discovered in a Taskfile, with its namespace prefix (if
+// it came from an include) already applied to Name.
 type taskInfo struct {
-	Name string `json:"name"`
-	Desc string `json:"desc"`
+	Name string
+	Desc string
+}
+
+// rawTaskfile captures only the parts of a Taskfile we care about for listing:
+// the task definitions and any includes. Values are decoded loosely (into any)
+// because a task may be a map (with desc/internal) or a bare list of commands,
+// and an include may be a string or a map.
+type rawTaskfile struct {
+	Includes map[string]any `yaml:"includes"`
+	Tasks    map[string]any `yaml:"tasks"`
 }
 
 // RunTaskfile delegates execution to the "task" runner if a Taskfile.yaml exists
@@ -30,28 +44,33 @@ func RunTaskfile() {
 	Run("task", run.Args(os.Args[1:]...))
 }
 
-// Tasks discovers tasks defined in the project's Taskfile.yaml (via
-// `task --list-all --json`) and exposes them as go-make Tasks that forward
-// to the `task` binary. This makes Taskfile tasks discoverable in `make help`
-// and runnable as first-class go-make tasks during migration. Returns an empty
-// Task group when no Taskfile.yaml is present so it can be embedded
-// unconditionally in a Makefile.
+// Tasks discovers tasks defined in the project's Taskfile.yaml (and any local
+// `includes:`) by parsing the YAML directly, and exposes them as go-make Tasks
+// that forward to the `task` binary. This makes Taskfile tasks discoverable in
+// `make help` and runnable as first-class go-make tasks during migration.
+// Returns an empty Task group when no Taskfile.yaml is present so it can be
+// embedded unconditionally in a Makefile.
 //
-// PERFORMANCE: unlike the other task constructors, this one shells out to the
-// `task` binary at construction time (i.e. on every `make` invocation, even for
-// native tasks), so prefer it only while migrating away from Task. Once tasks
-// are ported to go-make, drop the Tasks() call to avoid the per-invocation cost.
+// Discovery mirrors `task --list-all`: internal tasks and internal includes are
+// omitted. Remote includes (http/git) are skipped, since listing them would
+// require fetching — those tasks won't appear here, though RunTaskfile still
+// forwards to them.
+//
+// PERFORMANCE: the Taskfile(s) are parsed at construction time, i.e. on every
+// `make` invocation (even for native tasks). Parsing YAML is cheap but not free,
+// so prefer this only while migrating away from Task; once tasks are ported to
+// go-make, drop the Tasks() call to avoid the per-invocation cost.
 //
 // The optional globs select which discovered tasks to expose: a glob may be
 // an exact task name ("build") or a pattern ("db:*"). A task is included when
 // it matches any glob. When no globs are given, all tasks are exposed.
 func Tasks(globs ...string) Task {
-	if file.FindParent(git.Root(), "Taskfile.yaml") == "" {
+	taskfilePath := file.FindParent(git.Root(), "Taskfile.yaml")
+	if taskfilePath == "" {
 		return Task{}
 	}
 
-	out := lang.Return(run.Command("task", run.Args("--list-all", "--json"), run.Quiet()))
-	listed := parseTaskListing(out)
+	listed := discoverTasks(taskfilePath)
 
 	subtasks := make([]Task, 0, len(listed))
 	for _, info := range listed {
@@ -86,19 +105,122 @@ func matchesAny(name string, globs []string) bool {
 	return false
 }
 
-// parseTaskListing parses the JSON output of `task --list-all --json` into the
-// list of tasks it describes. Returns nil for empty input or a payload with no
-// tasks. Panics if the JSON is malformed.
-func parseTaskListing(out string) []taskInfo {
-	if out == "" {
-		return nil
+// discoverTasks parses the Taskfile at path and all of its local includes,
+// returning the flattened, namespaced task list sorted by name. Panics on
+// malformed YAML or unreadable referenced files.
+func discoverTasks(path string) []taskInfo {
+	var out []taskInfo
+	collectTasks(path, "", nil, &out)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// collectTasks appends the tasks defined in the Taskfile at path to out,
+// prefixing each name with prefix (the accumulated include namespace), then
+// recurses into local includes. ancestors holds the absolute paths in the
+// current include chain so cycles terminate while diamonds are still followed.
+func collectTasks(path, prefix string, ancestors []string, out *[]taskInfo) {
+	abs := lang.Return(filepath.Abs(path))
+	if slices.Contains(ancestors, abs) {
+		return // cycle in the include graph
 	}
-	var parsed struct {
-		Tasks []taskInfo `json:"tasks"`
+	ancestors = append(ancestors, abs)
+
+	var doc rawTaskfile
+	lang.Throw(yaml.Unmarshal([]byte(file.Read(path)), &doc))
+
+	for name, raw := range doc.Tasks {
+		m, isMap := raw.(map[string]any)
+		// `task` never lists internal tasks, even with --list-all.
+		if internal, _ := m["internal"].(bool); isMap && internal {
+			continue
+		}
+		desc, _ := m["desc"].(string) // empty for non-map (bare command list) forms
+		*out = append(*out, taskInfo{Name: prefix + name, Desc: desc})
 	}
-	lang.Throw(json.Unmarshal([]byte(out), &parsed))
-	if len(parsed.Tasks) == 0 {
-		return nil
+
+	baseDir := filepath.Dir(path)
+	for namespace, raw := range doc.Includes {
+		inc := parseInclude(raw)
+		// remote and internal includes aren't listable without fetching/running.
+		if inc.remote || inc.internal {
+			continue
+		}
+		incPath := resolveIncludePath(baseDir, inc.taskfile)
+		if incPath == "" {
+			continue // optional or otherwise unresolved include
+		}
+		childPrefix := prefix + namespace + ":"
+		if inc.flatten {
+			// flattened includes contribute their tasks without a namespace.
+			childPrefix = prefix
+		}
+		collectTasks(incPath, childPrefix, ancestors, out)
 	}
-	return parsed.Tasks
+}
+
+// includeRef is the normalized form of a Taskfile `includes:` entry.
+type includeRef struct {
+	taskfile string
+	optional bool
+	internal bool
+	flatten  bool
+	remote   bool
+}
+
+// parseInclude normalizes an include entry, which may be a bare string (the
+// taskfile path) or a map with taskfile/optional/internal/flatten keys.
+func parseInclude(raw any) includeRef {
+	switch v := raw.(type) {
+	case string:
+		return includeRef{taskfile: v, remote: isRemoteInclude(v)}
+	case map[string]any:
+		taskfile, _ := v["taskfile"].(string)
+		optional, _ := v["optional"].(bool)
+		internal, _ := v["internal"].(bool)
+		flatten, _ := v["flatten"].(bool)
+		return includeRef{
+			taskfile: taskfile,
+			optional: optional,
+			internal: internal,
+			flatten:  flatten,
+			remote:   isRemoteInclude(taskfile),
+		}
+	}
+	return includeRef{}
+}
+
+// isRemoteInclude reports whether ref points at a remote Taskfile (http or git),
+// which can't be listed without fetching it.
+func isRemoteInclude(ref string) bool {
+	return strings.HasPrefix(ref, "http://") ||
+		strings.HasPrefix(ref, "https://") ||
+		strings.HasPrefix(ref, "git+") ||
+		strings.Contains(ref, "git@")
+}
+
+// resolveIncludePath resolves an include's taskfile reference (relative to
+// baseDir) to a concrete file. When the reference points at a directory, the
+// conventional Taskfile names are tried in order. Returns "" when nothing is
+// found, so optional/missing includes are simply skipped.
+func resolveIncludePath(baseDir, ref string) string {
+	if ref == "" {
+		ref = "." // an empty/omitted taskfile means the directory itself
+	}
+	p := ref
+	if !filepath.IsAbs(p) {
+		p = filepath.Join(baseDir, ref)
+	}
+	if file.IsDir(p) {
+		for _, name := range []string{"Taskfile.yml", "Taskfile.yaml", "taskfile.yml", "taskfile.yaml"} {
+			if candidate := filepath.Join(p, name); file.Exists(candidate) {
+				return candidate
+			}
+		}
+		return ""
+	}
+	if file.Exists(p) {
+		return p
+	}
+	return ""
 }

--- a/tasks/gotask/taskfile.go
+++ b/tasks/gotask/taskfile.go
@@ -1,7 +1,10 @@
 package gotask
 
 import (
+	"encoding/json"
 	"os"
+
+	"github.com/bmatcuk/doublestar/v4"
 
 	. "github.com/anchore/go-make"
 	"github.com/anchore/go-make/file"
@@ -9,6 +12,12 @@ import (
 	"github.com/anchore/go-make/lang"
 	"github.com/anchore/go-make/run"
 )
+
+// taskInfo is one entry from `task --list-all --json` output.
+type taskInfo struct {
+	Name string `json:"name"`
+	Desc string `json:"desc"`
+}
 
 // RunTaskfile delegates execution to the "task" runner if a Taskfile.yaml exists
 // in the project. This allows gradual migration from Task to go-make by forwarding
@@ -19,4 +28,77 @@ func RunTaskfile() {
 		return
 	}
 	Run("task", run.Args(os.Args[1:]...))
+}
+
+// Tasks discovers tasks defined in the project's Taskfile.yaml (via
+// `task --list-all --json`) and exposes them as go-make Tasks that forward
+// to the `task` binary. This makes Taskfile tasks discoverable in `make help`
+// and runnable as first-class go-make tasks during migration. Returns an empty
+// Task group when no Taskfile.yaml is present so it can be embedded
+// unconditionally in a Makefile.
+//
+// PERFORMANCE: unlike the other task constructors, this one shells out to the
+// `task` binary at construction time (i.e. on every `make` invocation, even for
+// native tasks), so prefer it only while migrating away from Task. Once tasks
+// are ported to go-make, drop the Tasks() call to avoid the per-invocation cost.
+//
+// The optional globs select which discovered tasks to expose: a glob may be
+// an exact task name ("build") or a pattern ("db:*"). A task is included when
+// it matches any glob. When no globs are given, all tasks are exposed.
+func Tasks(globs ...string) Task {
+	if file.FindParent(git.Root(), "Taskfile.yaml") == "" {
+		return Task{}
+	}
+
+	out := lang.Return(run.Command("task", run.Args("--list-all", "--json"), run.Quiet()))
+	listed := parseTaskListing(out)
+
+	subtasks := make([]Task, 0, len(listed))
+	for _, info := range listed {
+		if !matchesAny(info.Name, globs) {
+			continue
+		}
+		subtasks = append(subtasks, Task{
+			Name:        info.Name,
+			Description: info.Desc,
+			Run: func() {
+				// forward this specific task by name (not os.Args) so multi-task
+				// and dependency-driven invocations dispatch the right task.
+				Run("task", run.Args(info.Name))
+			},
+		})
+	}
+	return Task{Tasks: subtasks}
+}
+
+// matchesAny reports whether name matches any of the given glob patterns. An
+// empty glob list matches everything. Patterns may be exact task names or
+// doublestar globs (e.g. "db:*"). Panics if a glob is malformed.
+func matchesAny(name string, globs []string) bool {
+	if len(globs) == 0 {
+		return true
+	}
+	for _, glob := range globs {
+		if lang.Return(doublestar.Match(glob, name)) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseTaskListing parses the JSON output of `task --list-all --json` into the
+// list of tasks it describes. Returns nil for empty input or a payload with no
+// tasks. Panics if the JSON is malformed.
+func parseTaskListing(out string) []taskInfo {
+	if out == "" {
+		return nil
+	}
+	var parsed struct {
+		Tasks []taskInfo `json:"tasks"`
+	}
+	lang.Throw(json.Unmarshal([]byte(out), &parsed))
+	if len(parsed.Tasks) == 0 {
+		return nil
+	}
+	return parsed.Tasks
 }

--- a/tasks/gotask/taskfile_test.go
+++ b/tasks/gotask/taskfile_test.go
@@ -1,0 +1,95 @@
+package gotask
+
+import (
+	"testing"
+
+	"github.com/anchore/go-make/require"
+)
+
+func TestParseTaskListing(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []taskInfo
+	}{
+		{
+			name: "empty output yields no tasks",
+			out:  "",
+			want: nil,
+		},
+		{
+			name: "names and descriptions are extracted",
+			out: `{
+				"tasks": [
+					{"name": "build", "desc": "build the binary"},
+					{"name": "internal", "desc": ""},
+					{"name": "test", "desc": "run tests"}
+				],
+				"location": "/proj/Taskfile.yaml"
+			}`,
+			want: []taskInfo{
+				{Name: "build", Desc: "build the binary"},
+				{Name: "internal", Desc: ""},
+				{Name: "test", Desc: "run tests"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, parseTaskListing(tt.out))
+		})
+	}
+}
+
+func TestMatchesAny(t *testing.T) {
+	tests := []struct {
+		name     string
+		taskName string
+		globs    []string
+		want     bool
+	}{
+		{
+			name:     "no globs matches everything",
+			taskName: "build",
+			globs:    nil,
+			want:     true,
+		},
+		{
+			name:     "exact name matches",
+			taskName: "build",
+			globs:    []string{"build"},
+			want:     true,
+		},
+		{
+			name:     "exact name does not match other task",
+			taskName: "test",
+			globs:    []string{"build"},
+			want:     false,
+		},
+		{
+			name:     "prefix glob matches namespaced task",
+			taskName: "db:migrate",
+			globs:    []string{"db:*"},
+			want:     true,
+		},
+		{
+			name:     "prefix glob does not match unrelated task",
+			taskName: "build",
+			globs:    []string{"db:*"},
+			want:     false,
+		},
+		{
+			name:     "matches when any glob matches",
+			taskName: "test",
+			globs:    []string{"build", "test", "db:*"},
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, matchesAny(tt.taskName, tt.globs))
+		})
+	}
+}

--- a/tasks/gotask/taskfile_test.go
+++ b/tasks/gotask/taskfile_test.go
@@ -1,43 +1,256 @@
 package gotask
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/anchore/go-make/require"
 )
 
-func TestParseTaskListing(t *testing.T) {
+func TestDiscoverTasks(t *testing.T) {
 	tests := []struct {
 		name string
-		out  string
-		want []taskInfo
+		// files maps a path (relative to a temp dir) to its YAML contents; the
+		// "Taskfile.yaml" entry is the root passed to discoverTasks.
+		files map[string]string
+		want  []taskInfo
 	}{
 		{
-			name: "empty output yields no tasks",
-			out:  "",
+			name: "extracts names and descriptions, sorted",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+tasks:
+  test:
+    desc: run tests
+  build:
+    desc: build the binary
+`,
+			},
+			want: []taskInfo{
+				{Name: "build", Desc: "build the binary"},
+				{Name: "test", Desc: "run tests"},
+			},
+		},
+		{
+			name: "internal tasks and bare command lists are handled",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+tasks:
+  build:
+    desc: build the binary
+  hidden:
+    internal: true
+    desc: should not be listed
+  oneliner:
+    - echo hi
+`,
+			},
+			want: []taskInfo{
+				{Name: "build", Desc: "build the binary"},
+				{Name: "oneliner", Desc: ""},
+			},
+		},
+		{
+			name: "includes are namespaced",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+includes:
+  db: ./db/Taskfile.yaml
+tasks:
+  build:
+    desc: build the binary
+`,
+				"db/Taskfile.yaml": `
+version: '3'
+tasks:
+  migrate:
+    desc: run migrations
+`,
+			},
+			want: []taskInfo{
+				{Name: "build", Desc: "build the binary"},
+				{Name: "db:migrate", Desc: "run migrations"},
+			},
+		},
+		{
+			name: "include pointing at a directory resolves the conventional Taskfile",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+includes:
+  db: ./db
+tasks:
+  build:
+    desc: build the binary
+`,
+				// note: directory reference, not a file; uses .yml (a tried name)
+				"db/Taskfile.yml": `
+version: '3'
+tasks:
+  migrate:
+    desc: run migrations
+`,
+			},
+			want: []taskInfo{
+				{Name: "build", Desc: "build the binary"},
+				{Name: "db:migrate", Desc: "run migrations"},
+			},
+		},
+		{
+			name: "nested includes are namespaced at every level",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+includes:
+  a: ./a
+tasks:
+  build:
+    desc: build the binary
+`,
+				"a/Taskfile.yml": `
+version: '3'
+includes:
+  b: ./b
+tasks:
+  lint:
+    desc: lint a
+`,
+				"a/b/Taskfile.yml": `
+version: '3'
+tasks:
+  test:
+    desc: test b
+`,
+			},
+			want: []taskInfo{
+				{Name: "a:b:test", Desc: "test b"},
+				{Name: "a:lint", Desc: "lint a"},
+				{Name: "build", Desc: "build the binary"},
+			},
+		},
+		{
+			name: "Taskfile with no tasks yields nothing",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+`,
+			},
 			want: nil,
 		},
 		{
-			name: "names and descriptions are extracted",
-			out: `{
-				"tasks": [
-					{"name": "build", "desc": "build the binary"},
-					{"name": "internal", "desc": ""},
-					{"name": "test", "desc": "run tests"}
-				],
-				"location": "/proj/Taskfile.yaml"
-			}`,
+			name: "the same Taskfile reached two ways keeps both namespaces (diamond)",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+includes:
+  x: ./shared
+  y: ./shared
+`,
+				"shared/Taskfile.yml": `
+version: '3'
+tasks:
+  common:
+    desc: shared task
+`,
+			},
+			want: []taskInfo{
+				{Name: "x:common", Desc: "shared task"},
+				{Name: "y:common", Desc: "shared task"},
+			},
+		},
+		{
+			name: "a cycle in the include graph terminates",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+includes:
+  b: ./b
+tasks:
+  root:
+    desc: root task
+`,
+				"b/Taskfile.yml": `
+version: '3'
+includes:
+  back: ../
+tasks:
+  loop:
+    desc: b task
+`,
+			},
+			// the include back to the root is dropped once the cycle is detected,
+			// so we still see root's task plus b's task (namespaced once).
+			want: []taskInfo{
+				{Name: "b:loop", Desc: "b task"},
+				{Name: "root", Desc: "root task"},
+			},
+		},
+		{
+			name: "flattened includes drop the namespace",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+includes:
+  extra:
+    taskfile: ./extra/Taskfile.yaml
+    flatten: true
+tasks:
+  build:
+    desc: build the binary
+`,
+				"extra/Taskfile.yaml": `
+version: '3'
+tasks:
+  lint:
+    desc: lint the code
+`,
+			},
 			want: []taskInfo{
 				{Name: "build", Desc: "build the binary"},
-				{Name: "internal", Desc: ""},
-				{Name: "test", Desc: "run tests"},
+				{Name: "lint", Desc: "lint the code"},
+			},
+		},
+		{
+			name: "internal and remote includes are skipped",
+			files: map[string]string{
+				"Taskfile.yaml": `
+version: '3'
+includes:
+  shared:
+    taskfile: ./shared/Taskfile.yaml
+    internal: true
+  remote: https://example.com/Taskfile.yaml
+tasks:
+  build:
+    desc: build the binary
+`,
+				"shared/Taskfile.yaml": `
+version: '3'
+tasks:
+  helper:
+    desc: a helper
+`,
+			},
+			want: []taskInfo{
+				{Name: "build", Desc: "build the binary"},
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, parseTaskListing(tt.out))
+			dir := t.TempDir()
+			for relPath, contents := range tt.files {
+				full := filepath.Join(dir, relPath)
+				require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+				require.NoError(t, os.WriteFile(full, []byte(contents), 0o644))
+			}
+			got := discoverTasks(filepath.Join(dir, "Taskfile.yaml"))
+			require.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Adds a `gotask.Tasks()` helper that discovers tasks from a project's `Taskfile.yaml` (~via `task --list-all --json`~ by parsing the `**/Taskfile.yaml` files) and exposes them as native go-make tasks that forward to the `task` binary. This makes it easy to embed an existing Taskfile into a go-make Makefile while migrating, without hand-redeclaring every task.

- `Tasks()` takes optional globs to pick which tasks to expose — exact names like `build` or patterns like `db:*`. No globs means all of them.
- Forwarded tasks pass through `os.Args[1:]` just like `RunTaskfile`, so Taskfile parameters/args keep working.
- Returns an empty task group when there's no `Taskfile.yaml`, so it's safe to embed unconditionally.

> [!WARNING]
> This has performance implications: ~`task` is invoked even if it's not used~ we always parse `Taskfile.yaml` files even if they are not used