### PR TITLE
Add break-glass feature for main branch checks on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,10 @@ on:
       version:
         description: tag the latest commit on main with the given version (prefixed with v)
         required: true
+      skip-checks:
+        description: skip the check gate that verifies required checks have passed on main
+        type: boolean
+        default: false
 
 run-name: ${{ github.event.inputs.version }}
 
@@ -24,6 +28,7 @@ jobs:
       version: ${{ github.event.inputs.version }}
 
   check-gate:
+    if: ${{ !inputs.skip-checks }}
     permissions:
       checks: read
       contents: read
@@ -35,6 +40,14 @@ jobs:
     needs: [check-gate, version-available]
     environment: release
     runs-on: ubuntu-24.04
+    # run even when check-gate is skipped, but never when version-available
+    # failed/was skipped, nor when check-gate failed or was cancelled. note:
+    # always() disables the implicit success() gate on ALL needs, so the
+    # version-available requirement must be re-asserted explicitly here.
+    if: >-
+      ${{ always()
+          && needs.version-available.result == 'success'
+          && !contains(fromJSON('["failure", "cancelled"]'), needs.check-gate.result) }}
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
Allow for main-branch checks to be bypassed on release