### PR TITLE
fix single target builds

### DIFF
--- a/tasks/goreleaser/snapshot.go
+++ b/tasks/goreleaser/snapshot.go
@@ -3,14 +3,13 @@ package goreleaser
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	. "github.com/anchore/go-make"
 	"github.com/anchore/go-make/file"
 	"github.com/anchore/go-make/lang"
 )
 
-func runSnapshot(extraArgs ...string) {
+func runSnapshot(singleTarget bool) {
 	file.Require(configName)
 
 	file.WithTempDir(func(tempDir string) {
@@ -24,12 +23,20 @@ func runSnapshot(extraArgs ...string) {
 
 		file.Write(dstConfig, configContent)
 
-		args := fmt.Sprintf(`goreleaser release --clean --snapshot --skip=publish --skip=sign --config=%s`, dstConfig)
-		if len(extraArgs) > 0 {
-			args += " " + strings.Join(extraArgs, " ")
-		}
-		Run(args)
+		Run(snapshotArgs(dstConfig, singleTarget))
 	})
+}
+
+// snapshotArgs builds the goreleaser command for a snapshot build. single-target
+// builds use `goreleaser build` (current OS/arch only) because --single-target is
+// a build-only flag — `goreleaser release` rejects it with "unknown flag". Full
+// snapshots use `goreleaser release` to exercise the whole release pipeline
+// (archives, packages, etc.) while skipping publish and sign.
+func snapshotArgs(config string, singleTarget bool) string {
+	if singleTarget {
+		return fmt.Sprintf("goreleaser build --clean --snapshot --single-target --config=%s", config)
+	}
+	return fmt.Sprintf("goreleaser release --clean --snapshot --skip=publish --skip=sign --config=%s", config)
 }
 
 // SnapshotTasks creates tasks for building snapshot (non-release) builds with goreleaser.
@@ -44,13 +51,13 @@ func SnapshotTasks() Task {
 		Name:         "snapshot",
 		Description:  "build a snapshot release with goreleaser",
 		Dependencies: Deps("release:dependencies"),
-		Run:          func() { runSnapshot() },
+		Run:          func() { runSnapshot(false) },
 		Tasks: []Task{
 			{
 				Name:         "snapshot:single-target",
 				Description:  "build a snapshot release with goreleaser for a single target",
 				Dependencies: Deps("release:dependencies"),
-				Run:          func() { runSnapshot("--single-target") },
+				Run:          func() { runSnapshot(true) },
 			},
 			{
 				Name:        "snapshots:clean",

--- a/tasks/goreleaser/snapshot_test.go
+++ b/tasks/goreleaser/snapshot_test.go
@@ -1,0 +1,36 @@
+package goreleaser
+
+import (
+	"testing"
+
+	"github.com/anchore/go-make/require"
+)
+
+func Test_snapshotArgs(t *testing.T) {
+	tests := []struct {
+		name         string
+		config       string
+		singleTarget bool
+		want         string
+	}{
+		{
+			name:         "full snapshot uses release",
+			config:       "/tmp/x/.goreleaser.yaml",
+			singleTarget: false,
+			want:         "goreleaser release --clean --snapshot --skip=publish --skip=sign --config=/tmp/x/.goreleaser.yaml",
+		},
+		{
+			// --single-target is a build-only flag; `goreleaser release` rejects it.
+			name:         "single-target uses build",
+			config:       "/tmp/x/.goreleaser.yaml",
+			singleTarget: true,
+			want:         "goreleaser build --clean --snapshot --single-target --config=/tmp/x/.goreleaser.yaml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, snapshotArgs(tt.config, tt.singleTarget))
+		})
+	}
+}


### PR DESCRIPTION
We're trying to pass explicitly `--single-target` to goreleaser, however, this is not a valid flag for all commands. This changes from `release` to `build` as needed when the single target option is indicated.