### PR TITLE
Use golangci-lint as formatter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -103,10 +103,17 @@ issues:
 formatters:
   enable:
     - gofmt
-    - goimports
+    - gci
   exclusions:
     generated: lax
     paths:
       - third_party$
       - builtin$
       - examples$
+  settings:
+    gci:
+      # See https://golangci-lint.run/docs/formatters/configuration/#gci
+      sections:
+        - standard # Standard section: captures all standard packages.
+        - default # Default section: contains all imports that could not be matched to another section type.
+        - prefix(github.com/anchore)

--- a/tasks.go
+++ b/tasks.go
@@ -26,6 +26,13 @@ type Task struct {
 	//   - Referencing in RunsOn labels
 	Name string
 
+	// Aliases are additional names that resolve to this task, e.g. for keeping a
+	// legacy name working after a rename. `make <alias>` runs this task. Aliases
+	// are not shown in help.
+	//
+	// Example: Name: "lint:fix", Aliases: List("lint-fix")
+	Aliases []string
+
 	// Description is shown in help output. Keep it brief and action-oriented.
 	Description string
 
@@ -249,7 +256,7 @@ func (t *taskRunner) runTask(name string) {
 func (t *taskRunner) findByName(name string) []*Task {
 	var out []*Task
 	for _, task := range t.tasks {
-		if task.Name == name {
+		if task.Name == name || slices.Contains(task.Aliases, name) {
 			out = append(out, task)
 		}
 	}
@@ -269,9 +276,11 @@ func (t *taskRunner) findByLabel(name string) []*Task {
 func (t *taskRunner) Makefile() {
 	buildCmdDir := strings.TrimLeft(strings.TrimPrefix(file.Cwd(), RootDir()), `\/`)
 	for _, t := range t.tasks {
-		fmt.Printf(".PHONY: %s\n", t.Name)
-		fmt.Printf("%s:\n", t.Name)
-		fmt.Printf("\t@go run -C %s . %s\n", buildCmdDir, t.Name)
+		for _, name := range append([]string{t.Name}, t.Aliases...) {
+			fmt.Printf(".PHONY: %s\n", name)
+			fmt.Printf("%s:\n", name)
+			fmt.Printf("\t@go run -C %s . %s\n", buildCmdDir, name)
+		}
 	}
 	// catch-all, could be the entire script except for FreeBSD
 	fmt.Printf(".PHONY: *\n")

--- a/tasks/golint/format.go
+++ b/tasks/golint/format.go
@@ -2,6 +2,7 @@ package golint
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -34,7 +35,7 @@ type Option run.Option
 
 // SkipTests excludes test files from linting by adding --tests=false to golangci-lint.
 func SkipTests() Option {
-	return func(ctx context.Context, cmd *exec.Cmd) error {
+	return func(_ context.Context, cmd *exec.Cmd) error {
 		if strings.Contains(cmd.Args[0], "golangci-lint") {
 			cmd.Args = append(cmd.Args, "--tests=false")
 		}
@@ -42,13 +43,14 @@ func SkipTests() Option {
 	}
 }
 
-// Tasks creates the standard linting and formatting task group.
-// Includes static-analysis, format, and lint-fix tasks.
+// Tasks creates the standard linting and formatting task group. Includes
+// static-analysis, format, lint, and lint:fix tasks (with a lint-fix alias).
 func Tasks(options ...Option) Task {
 	return Task{
 		Tasks: []Task{
 			StaticAnalysisTask(options...),
 			FormatTask(),
+			LintTask(options...),
 			LintFixTask(options...),
 		},
 	}
@@ -86,29 +88,49 @@ func hasModTidyDiff() bool {
 	return lang.Return(strconv.Atoi(parts[1])) >= 23
 }
 
-// FormatTask creates a task that formats Go code using gofmt and gosimports,
-// and runs go mod tidy. gosimports groups local imports based on the module path.
+// FormatTask creates a task that formats Go code with golangci-lint's formatters
+// (gofmt and whatever else the project's golangci config enables) and runs go mod
+// tidy. When the project config doesn't enable an import-organizing formatter
+// (gci or goimports), we fall back to gosimports so imports are still grouped.
 func FormatTask() Task {
 	return Task{
 		Name:        "format",
 		Description: "format all source files",
 		Run: func() {
-			Run(`gofmt -w -s .`)
-			if template.Globals["LocalPackage"] != nil {
-				Run(`gosimports -local {{LocalPackage}} -w .`)
-			} else {
-				Run(`gosimports -w .`)
+			Run("golangci-lint fmt")
+			if !importFormatterEnabled() {
+				// GCI has replaced gosimports, however, this is controlled in each repo within their configuration.
+				// This will ensure gosimports is used when GCI is not enabled, so imports are still grouped.
+				if template.Globals["LocalPackage"] != nil {
+					Run(`gosimports -local {{LocalPackage}} -w .`)
+				} else {
+					Run(`gosimports -w .`)
+				}
 			}
 			Run(`go mod tidy`)
 		},
 	}
 }
 
+// LintTask creates a task that runs golangci-lint without any fixers (no
+// formatting, no --fix) — just the lint checks.
+func LintTask(options ...Option) Task {
+	return Task{
+		Name:        "lint",
+		Description: "run lint checks (no fixes)",
+		Run: func() {
+			Run("golangci-lint run", toRunOpts(options)...)
+		},
+	}
+}
+
 // LintFixTask creates a task that formats code and then runs golangci-lint
 // with the --fix flag to automatically fix linting issues where possible.
+// The legacy `lint-fix` name is kept as an alias.
 func LintFixTask(options ...Option) Task {
 	return Task{
-		Name:         "lint-fix",
+		Name:         "lint:fix",
+		Aliases:      lang.List("lint-fix"),
 		Description:  "format and run lint fix",
 		Dependencies: lang.List("format"),
 		Run: func() {
@@ -117,10 +139,11 @@ func LintFixTask(options ...Option) Task {
 	}
 }
 
+// toRunOpts converts lint Options into run.Options.
 func toRunOpts(options []Option) []run.Option {
-	var out []run.Option
-	for _, opt := range options {
-		out = append(out, run.Option(opt))
+	out := make([]run.Option, len(options))
+	for i, opt := range options {
+		out[i] = run.Option(opt)
 	}
 	return out
 }
@@ -153,4 +176,44 @@ func findMalformedFilenames(root string) error {
 	}
 
 	return nil
+}
+
+// importFormatters are golangci-lint formatters that organize imports; when the
+// project's config enables one of these, golangci-lint fmt already handles import
+// grouping and we don't also need gosimports.
+var importFormatters = []string{"gci", "goimports"}
+
+// importFormatterEnabled reports whether the project's golangci-lint config
+// enables a formatter that organizes imports. golangci-lint's own `formatters`
+// subcommand resolves the effective config (discovered natively), so we don't
+// have to parse arbitrary config ourselves.
+func importFormatterEnabled() bool {
+	out := Run("golangci-lint formatters --json", run.Quiet())
+	for _, name := range importFormatters {
+		if formatterEnabled(out, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// formatterEnabled reports whether name appears in the Enabled list of
+// `golangci-lint formatters --json` output. A parse failure is treated as "not
+// enabled" so callers fall back to their non-golangci-lint behavior.
+func formatterEnabled(formattersJSON, name string) bool {
+	var result struct {
+		Enabled []struct {
+			Name string `json:"name"`
+		}
+	}
+	if err := json.Unmarshal([]byte(formattersJSON), &result); err != nil {
+		log.Debug("unable to parse golangci-lint formatters output: %v", err)
+		return false
+	}
+	for _, f := range result.Enabled {
+		if f.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/tasks/golint/format_test.go
+++ b/tasks/golint/format_test.go
@@ -1,0 +1,59 @@
+package golint
+
+import (
+	"testing"
+
+	"github.com/anchore/go-make/require"
+)
+
+func TestFormatterEnabled(t *testing.T) {
+	tests := []struct {
+		name           string
+		formattersJSON string
+		formatter      string
+		want           bool
+	}{
+		{
+			name:           "gci enabled",
+			formattersJSON: `{"Enabled":[{"name":"gci"},{"name":"gofmt"}],"Disabled":[{"name":"gofumpt"}]}`,
+			formatter:      "gci",
+			want:           true,
+		},
+		{
+			name:           "goimports enabled",
+			formattersJSON: `{"Enabled":[{"name":"gofmt"},{"name":"goimports"}],"Disabled":[{"name":"gci"}]}`,
+			formatter:      "goimports",
+			want:           true,
+		},
+		{
+			name:           "formatter only in disabled",
+			formattersJSON: `{"Enabled":[{"name":"gofmt"}],"Disabled":[{"name":"gci"}]}`,
+			formatter:      "gci",
+			want:           false,
+		},
+		{
+			name:           "no formatters enabled (null)",
+			formattersJSON: `{"Enabled":null,"Disabled":[{"name":"gci"}]}`,
+			formatter:      "gci",
+			want:           false,
+		},
+		{
+			name:           "malformed json",
+			formattersJSON: `not json`,
+			formatter:      "gci",
+			want:           false,
+		},
+		{
+			name:           "empty string",
+			formattersJSON: ``,
+			formatter:      "gci",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, formatterEnabled(tt.formattersJSON, tt.formatter))
+		})
+	}
+}

--- a/tasks/goreleaser/release.go
+++ b/tasks/goreleaser/release.go
@@ -19,7 +19,7 @@ func Tasks() Task {
 	return Task{
 		Tasks: []Task{
 			SnapshotTasks(),               // `make snapshot` to build a local snapshot to ./snapshot
-			ReleaseTask(),                 // `make ci-release` for building and publishing a release with goreleaser
+			ReleaseTask(),                 // `make ci:release` (alias `ci-release`) to build and publish a release with goreleaser
 			release.WorkflowReleaseTask(), // `make release` to trigger the release.yaml workflow
 			release.ChangelogTask(),       // `make changelog` to generate and show changes since the last release
 		},
@@ -28,11 +28,12 @@ func Tasks() Task {
 
 // ReleaseTask creates a task for running goreleaser in CI environments.
 // Requires CI=true, a version tag on HEAD, and optional quill/syft tools
-// for signing and SBOM generation.
+// for signing and SBOM generation. It has no Description so it stays hidden
+// from `help`.
 func ReleaseTask() Task {
 	return Task{
-		Name:         "ci-release",
-		Description:  "build and publish a release with goreleaser",
+		Name:         "ci:release",
+		Aliases:      []string{"ci-release"},
 		Dependencies: Deps("release:dependencies"),
 		Run: func() {
 			file.Require(configName)

--- a/tasks/release/release.go
+++ b/tasks/release/release.go
@@ -14,7 +14,7 @@ func Tasks() Task {
 		Tasks: []Task{
 			ChangelogTask(),       // `make chanagelog` to generate and show changes since the last release
 			WorkflowReleaseTask(), // `make release` to trigger the release.yaml workflow
-			TagReleaseTask(),      // `make ci-release` for publishing a tag and creating a GH release
+			TagReleaseTask(),      // `make ci:release` (alias `ci-release`) to publish a tag and create a GH release
 		},
 	}
 }
@@ -34,8 +34,8 @@ func Tasks() Task {
 //  5. Create the GitHub release with the changelog
 func TagReleaseTask() Task {
 	return Task{
-		Name:        "ci-release",
-		Description: "creates a GitHub release (to be run in CI only)",
+		Name:    "ci:release",
+		Aliases: []string{"ci-release"},
 		Run: func() {
 			ensureNoGoreleaserConfig()
 

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -8,6 +8,29 @@ import (
 	"github.com/anchore/go-make/run"
 )
 
+func Test_taskAliasResolution(t *testing.T) {
+	ran := 0
+	r := taskRunner{}
+	r.addTasks(Task{
+		Name:        "lint:fix",
+		Aliases:     []string{"lint-fix"},
+		Description: "format and run lint fix",
+		Run:         func() { ran++ },
+	})
+
+	// the alias resolves to the real task
+	found := r.findByName("lint-fix")
+	require.Equal(t, 1, len(found))
+	require.Equal(t, "lint:fix", found[0].Name)
+
+	// an unknown name resolves to nothing
+	require.Equal(t, 0, len(r.findByName("nope")))
+
+	// running via the alias executes the real task exactly once
+	r.Run("lint-fix")
+	require.Equal(t, 1, ran)
+}
+
 func Test_errorsIncludeStackTrace(t *testing.T) {
 	stderr := bytes.Buffer{}
 	_, err := run.Command("go", run.Args("run", "./testdata/failure-example", "example-failure"), run.Stderr(&stderr))


### PR DESCRIPTION
This pivots to using `gci` over `goimports` or `gosimports`, since `gci` does everything we need under one tool. In that same vein, we are replacing `gofmt` with `golangci-lint fmt` so that all formatting is done under one tool. This will use the golangci lint configuration to understand if `gosimports` needs to be run or not based off of the presence of `gci` or `goimports`.

This additionally makes the following changes:
- Adds `lint` task
- Renames `lint-fix` to `lint:fix` to be consistent with other tasks and adds an alias for backwards compatibility
- Adds task aliasing so we don't need to write wrapper tasks