### PR TITLE
release pipeline refactor

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,9 +1,4 @@
 rules:
-  unpinned-uses:
-    config:
-      policies:
-        # anchore actions are internal; using @main is acceptable
-        anchore/*: any
   github-env:
     # writing GO_MOD_CACHE/GO_BUILD_CACHE to $GITHUB_ENV is safe here: the values come
     # from `go env` (trusted toolchain output), not from user-controlled input


### PR DESCRIPTION
quick pass refactoring go-make's release pipeline. turns out almost everything was already in place on main (TAG_TOKEN, skip-checks input, check-gate if + permissions, the release-job always() gate, and the native gci formatter in golangci), so this ended up being a tiny one:

- dropped the `unpinned-uses` block from zizmor.yml (kept the existing `github-env` rule)

a few items were N/A here:
- go-make self-bump: this IS the go-make repo and `.make/main.go` is part of the root module (no separate `.make/go.mod`), so there's nothing to bump
- dependabot: no grouping config to remove, and no `/.make` entry needed since `.make` isn't its own gomod module
- release.yaml DEPLOY_KEY / manual tag step: none present; ci-release already handles tagging via TAG_TOKEN