### PR TITLE
Leverage changelog cache where possible

### DIFF
--- a/tasks/goreleaser/release.go
+++ b/tasks/goreleaser/release.go
@@ -41,7 +41,9 @@ func ReleaseTask() Task {
 			tagName := ci.ReleaseTagInput()
 
 			ci.PublishTag(tagName)
-			changelogFile, _ := release.GenerateAndShowChangelog()
+			// fetch the pre-built changelog from the OCI cache (falls back to generating it
+			// with chronicle if the cache is unavailable)
+			changelogFile, _ := release.GetChangelog(tagName)
 
 			Run(`goreleaser release --clean --release-notes`, run.Args(changelogFile))
 		},

--- a/tasks/release/changelog.go
+++ b/tasks/release/changelog.go
@@ -6,7 +6,6 @@ import (
 
 	. "github.com/anchore/go-make"
 	"github.com/anchore/go-make/file"
-	"github.com/anchore/go-make/log"
 	"github.com/anchore/go-make/run"
 )
 
@@ -24,6 +23,11 @@ func ChangelogTask() Task {
 		Run:         func() { GenerateAndShowChangelog() },
 		Tasks: []Task{
 			{
+				Name:        "changelog:cache",
+				Description: "fetch the release changelog from the OCI cache (falls back to generating it)",
+				Run:         func() { GetChangelog("") },
+			},
+			{
 				Name: "clean",
 				Run: func() {
 					file.Delete(changelogFile)
@@ -37,16 +41,10 @@ func ChangelogTask() Task {
 // CHANGELOG.md, and displays it (using glow if available for better formatting).
 // Returns paths to the generated changelog and version files.
 func GenerateAndShowChangelog() (changelogFilePath, versionFilePath string) {
-	// gh auth status will fail the user is not authenticated
-	log.Debug(Run("gh auth status"))
-
-	ghAuthToken := Run("gh auth token")
-	log.Debug("Auth token: %.10s...", ghAuthToken)
-
 	Run(
 		fmt.Sprintf(`chronicle -n -o version=%s -o md=%s -o md-pretty`, versionFile, changelogFile),
 		run.Stdout(os.Stderr),
-		run.Env("GITHUB_TOKEN", ghAuthToken),
+		run.Env("GITHUB_TOKEN", githubToken()),
 	)
 
 	return changelogFile, versionFile
@@ -56,16 +54,10 @@ func GenerateAndShowChangelog() (changelogFilePath, versionFilePath string) {
 // --until-tag flag. This is useful when the tag already exists locally and we want to generate
 // the changelog up to and including that tag. Returns the changelog file path.
 func GenerateAndShowFromVersion(version string) string {
-	// gh auth status will fail the user is not authenticated
-	log.Debug(Run("gh auth status"))
-
-	ghAuthToken := Run("gh auth token")
-	log.Debug("Auth token: %.10s...", ghAuthToken)
-
 	Run(
 		fmt.Sprintf(`chronicle -n --until-tag %s -o md=%s -o md-pretty`, version, changelogFile),
 		run.Stdout(os.Stderr),
-		run.Env("GITHUB_TOKEN", ghAuthToken),
+		run.Env("GITHUB_TOKEN", githubToken()),
 	)
 
 	return changelogFile

--- a/tasks/release/changelog_cache.go
+++ b/tasks/release/changelog_cache.go
@@ -1,0 +1,461 @@
+package release
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	. "github.com/anchore/go-make"
+	"github.com/anchore/go-make/color"
+	"github.com/anchore/go-make/file"
+	"github.com/anchore/go-make/gomod"
+	"github.com/anchore/go-make/log"
+	"github.com/anchore/go-make/run"
+)
+
+const (
+	// changelogCacheRegistry is the OCI registry hosting the pre-built changelog artifacts.
+	changelogCacheRegistry = "ghcr.io"
+
+	// changelogCacheNamespace is the repository namespace under which each project publishes
+	// its changelog artifact, one repository per project tagged by full git commit SHA
+	// (e.g. ghcr.io/anchore/changelog/syft:<commit>).
+	changelogCacheNamespace = "anchore/changelog"
+
+	// changelogMarkdownSuffix identifies the rendered markdown layer within the artifact
+	// (matched against the org.opencontainers.image.title annotation).
+	changelogMarkdownSuffix = ".md"
+
+	// cacheFetchAttempts and cacheFetchBackoff control how aggressively transient registry
+	// failures (5xx, non-auth 4xx, network blips) are retried before giving up and falling
+	// back to generating the changelog locally.
+	cacheFetchAttempts = 4
+	cacheFetchBackoff  = 1 * time.Second
+
+	// maxManifestDepth bounds index->manifest resolution so a pathological or self-referential
+	// index returns an error (and falls back) instead of recursing forever.
+	maxManifestDepth = 4
+)
+
+// manifestAccept advertises every manifest media type we know how to parse so the registry
+// returns the artifact manifest (or an index pointing at it) rather than a 406.
+const manifestAccept = "application/vnd.oci.image.manifest.v1+json," +
+	"application/vnd.oci.image.index.v1+json," +
+	"application/vnd.docker.distribution.manifest.v2+json," +
+	"application/vnd.docker.distribution.manifest.list.v2+json"
+
+// majorVersionSuffix matches a trailing major-version path segment like "/v2".
+var majorVersionSuffix = regexp.MustCompile(`/v\d+$`)
+
+// seams allowing tests to drive GetChangelog's fallback decision without a live registry or
+// chronicle; production wiring points at the real implementations.
+var (
+	fetchCachedChangelogFn = fetchCachedChangelog
+	fallbackChangelogFn    = fallbackChangelog
+	writeAndShowFn         = writeAndShow
+)
+
+// GetChangelog resolves the release changelog for the current HEAD commit, preferring the
+// pre-built artifact published to the OCI changelog cache over regenerating it in the pipeline.
+// It returns the changelog file path and the computed release version.
+//
+// On any cache failure (a missing artifact, an auth problem, or transient registry errors that
+// outlast the retries) it falls back to generating the changelog locally with chronicle, exactly
+// as the pipeline did before the cache existed. Pass the release version when it is already known
+// (CI publish jobs) so the fallback can scope to that tag; pass "" (the release trigger) to let
+// chronicle compute the next version.
+func GetChangelog(version string) (changelogFilePath, computedVersion string) {
+	c, err := fetchCachedChangelogFn()
+	switch {
+	case err != nil:
+		log.Debug("changelog cache unavailable, falling back to chronicle: %v", err)
+		return fallbackChangelogFn(version)
+	case version == "" && c.version == "":
+		// cache hit lacked a version and the caller needs one; treat it as a miss so we
+		// fall back to chronicle instead of handing back an empty version.
+		log.Debug("changelog cache hit lacked a version, falling back to chronicle")
+		return fallbackChangelogFn(version)
+	}
+
+	writeAndShowFn(c)
+	// prefer the caller-supplied tag (authoritative) over the commit-keyed cached version,
+	// which may differ from the tag actually being published.
+	if version != "" {
+		return changelogFile, version
+	}
+	return changelogFile, c.version
+}
+
+// fallbackChangelog generates the changelog locally with chronicle, exactly as the pipeline did
+// before the cache existed, and notes the miss beneath the rendered changelog.
+func fallbackChangelog(version string) (changelogFilePath, computedVersion string) {
+	defer noteCacheMiss()
+	if version == "" {
+		_, versionFilePath := GenerateAndShowChangelog()
+		return changelogFile, strings.TrimSpace(file.Read(versionFilePath))
+	}
+	return GenerateAndShowFromVersion(version), version
+}
+
+// noteCacheMiss prints a subtle, greyed-out note beneath the (already-displayed) changelog so it
+// is clear the cache was skipped without drowning out the changelog itself.
+func noteCacheMiss() {
+	_, _ = fmt.Fprintln(os.Stderr, color.Grey("(changelog cache unavailable — generated locally)"))
+}
+
+// writeAndShow persists the cached changelog (and version, when present) to disk and prints the
+// cached markdown directly to stderr. Unlike the chronicle path (which pretty-renders via
+// md-pretty), this surfaces the markdown exactly as it was published to the cache.
+func writeAndShow(c cachedChangelog) {
+	file.Write(changelogFile, c.markdown)
+	if c.version != "" {
+		file.Write(versionFile, c.version)
+	}
+	_, _ = fmt.Fprintln(os.Stderr, c.markdown)
+}
+
+// cachedChangelog is the subset of the OCI changelog artifact we consume: the rendered markdown
+// and the computed release version.
+type cachedChangelog struct {
+	markdown string
+	version  string
+}
+
+// fetchCachedChangelog pulls the changelog artifact for HEAD from the OCI cache, retrying only
+// on transient errors (5xx, rate limiting, network blips). Definitive failures (a missing
+// artifact, auth problems) return immediately so the caller can fall back without delay.
+func fetchCachedChangelog() (cachedChangelog, error) {
+	// resolve setup inputs without panicking so a missing go.mod or git failure degrades to
+	// the chronicle fallback rather than aborting the release.
+	name, err := projectName()
+	if err != nil {
+		return cachedChangelog{}, err
+	}
+	repo := changelogCacheNamespace + "/" + name
+
+	commit, err := run.Command("git", run.Args("rev-parse", "HEAD"))
+	if err != nil {
+		return cachedChangelog{}, fmt.Errorf("resolving HEAD commit: %w", err)
+	}
+	commit = strings.TrimSpace(commit)
+
+	c := &ociClient{
+		scheme:   "https",
+		registry: changelogCacheRegistry,
+		repo:     repo,
+		ghToken:  githubToken(),
+		http:     &http.Client{Timeout: 30 * time.Second},
+	}
+
+	log.Info("getting changelog")
+	log.Debug("fetching changelog from cache: %s/%s:%s", c.registry, repo, commit)
+
+	ctx := context.Background()
+	var lastErr error
+	backoff := cacheFetchBackoff
+	for attempt := 1; attempt <= cacheFetchAttempts; attempt++ {
+		cl, err := c.pull(ctx, commit)
+		if err == nil {
+			return cl, nil
+		}
+		if !isRetryable(err) {
+			return cachedChangelog{}, err
+		}
+
+		lastErr = err
+		log.Debug("changelog cache fetch attempt %d/%d failed: %v", attempt, cacheFetchAttempts, err)
+		if attempt < cacheFetchAttempts {
+			time.Sleep(backoff)
+			backoff *= 2
+		}
+	}
+
+	return cachedChangelog{}, fmt.Errorf("changelog cache unavailable after %d attempts: %w", cacheFetchAttempts, lastErr)
+}
+
+// ociClient is a minimal read-only OCI distribution client, just enough to resolve an artifact
+// manifest and pull a single named blob from it.
+type ociClient struct {
+	scheme   string // "https" in production; overridable for tests
+	registry string
+	repo     string
+	ghToken  string
+	bearer   string
+	http     *http.Client
+}
+
+// pull authenticates, resolves the artifact manifest at ref, and returns its changelog markdown
+// (required) and version (best-effort: the version layer may be absent and callers that need it
+// validate separately).
+func (c *ociClient) pull(ctx context.Context, ref string) (cachedChangelog, error) {
+	if err := c.authenticate(ctx); err != nil {
+		return cachedChangelog{}, err
+	}
+
+	m, err := c.getManifest(ctx, ref, 0)
+	if err != nil {
+		return cachedChangelog{}, err
+	}
+
+	mdLayer, ok := findLayer(m.Layers, isMarkdownLayer)
+	if !ok {
+		// a resolved manifest without a markdown layer is a structural miss, not a transient
+		// error, so fall back immediately rather than retrying.
+		return cachedChangelog{}, &cacheMissError{reason: fmt.Sprintf("no markdown layer found in changelog artifact %s:%s", c.repo, ref)}
+	}
+	md, err := c.getBlob(ctx, mdLayer.Digest)
+	if err != nil {
+		return cachedChangelog{}, err
+	}
+	if len(strings.TrimSpace(md)) == 0 {
+		// an empty changelog blob would silently produce empty release notes; treat it as a
+		// structural miss so we fall back to chronicle.
+		return cachedChangelog{}, &cacheMissError{reason: fmt.Sprintf("empty changelog markdown in artifact %s:%s", c.repo, ref)}
+	}
+
+	out := cachedChangelog{markdown: md}
+
+	if verLayer, ok := findLayer(m.Layers, isVersionLayer); ok {
+		ver, err := c.getBlob(ctx, verLayer.Digest)
+		if err != nil {
+			return cachedChangelog{}, err
+		}
+		out.version = strings.TrimSpace(ver)
+	}
+
+	return out, nil
+}
+
+func (c *ociClient) getBlob(ctx context.Context, digest string) (string, error) {
+	blobURL := fmt.Sprintf("%s://%s/v2/%s/blobs/%s", c.scheme, c.registry, c.repo, digest)
+	body, err := c.get(ctx, blobURL, "")
+	return string(body), err
+}
+
+// authenticate exchanges the GitHub token (or anonymous access) for a pull-scoped bearer token
+// from the registry's token endpoint.
+func (c *ociClient) authenticate(ctx context.Context) error {
+	scope := "repository:" + c.repo + ":pull"
+	tokenURL := fmt.Sprintf("%s://%s/token?service=%s&scope=%s", c.scheme, c.registry, c.registry, url.QueryEscape(scope))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+	if err != nil {
+		return err
+	}
+	if c.ghToken != "" {
+		// any username paired with the token works for ghcr token exchange
+		req.Header.Set("Authorization", "Basic "+basicAuth("x-access-token", c.ghToken))
+	}
+
+	body, err := c.do(req, "token endpoint")
+	if err != nil {
+		return err
+	}
+
+	var t struct {
+		Token       string `json:"token"`
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &t); err != nil {
+		return fmt.Errorf("decoding token response: %w", err)
+	}
+
+	c.bearer = t.Token
+	if c.bearer == "" {
+		c.bearer = t.AccessToken
+	}
+	if c.bearer == "" {
+		return fmt.Errorf("empty token from %s", c.registry)
+	}
+	return nil
+}
+
+// getManifest resolves the manifest at ref, following an index to its first child manifest. depth
+// bounds that recursion (see maxManifestDepth) so a self-referential index errors out.
+func (c *ociClient) getManifest(ctx context.Context, ref string, depth int) (*ociManifest, error) {
+	if depth >= maxManifestDepth {
+		return nil, fmt.Errorf("manifest resolution exceeded depth %d for %s:%s", maxManifestDepth, c.repo, ref)
+	}
+
+	manifestURL := fmt.Sprintf("%s://%s/v2/%s/manifests/%s", c.scheme, c.registry, c.repo, ref)
+	body, err := c.get(ctx, manifestURL, manifestAccept)
+	if err != nil {
+		return nil, err
+	}
+
+	var m ociManifest
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, fmt.Errorf("decoding manifest: %w", err)
+	}
+
+	// if we got an index, resolve to the first child manifest it points at
+	if len(m.Manifests) > 0 {
+		return c.getManifest(ctx, m.Manifests[0].Digest, depth+1)
+	}
+	return &m, nil
+}
+
+func (c *ociClient) get(ctx context.Context, urlString, accept string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlString, nil)
+	if err != nil {
+		return nil, err
+	}
+	if accept != "" {
+		req.Header.Set("Accept", accept)
+	}
+	if c.bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+c.bearer)
+	}
+	return c.do(req, urlString)
+}
+
+// do performs the request and normalizes the response into ([]byte, error), surfacing non-2xx
+// responses as a statusError so the caller can decide whether to retry.
+func (c *ociClient) do(req *http.Request, what string) ([]byte, error) {
+	log.Debug("changelog cache %s %s", req.Method, what)
+
+	// the request host and scheme are fixed constants (https + ghcr.io); only the URL path is
+	// derived from project/commit metadata, so gosec's SSRF taint warning is a false positive here.
+	rsp, err := c.http.Do(req) //nolint:gosec // G704: destination host/scheme are constant, not attacker-controllable
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rsp.Body.Close() }()
+
+	body, err := io.ReadAll(rsp.Body)
+	if err != nil {
+		// a mid-read transport drop must not pass partial bytes off as a complete body; surface
+		// it as a (retryable) transport error so we retry and then fall back.
+		return nil, err
+	}
+
+	if rsp.StatusCode >= 200 && rsp.StatusCode < 300 {
+		return body, nil
+	}
+	return nil, &statusError{status: rsp.StatusCode, what: what, body: truncate(body)}
+}
+
+type ociManifest struct {
+	MediaType string          `json:"mediaType"`
+	Manifests []ociDescriptor `json:"manifests"` // populated when the response is an index
+	Layers    []ociDescriptor `json:"layers"`    // populated for an image/artifact manifest
+}
+
+type ociDescriptor struct {
+	MediaType   string            `json:"mediaType"`
+	Digest      string            `json:"digest"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+// findLayer returns the first layer matching the predicate, which receives the (lowercased)
+// title annotation and media type of each layer.
+func findLayer(layers []ociDescriptor, match func(title, mediaType string) bool) (ociDescriptor, bool) {
+	for _, l := range layers {
+		title := strings.ToLower(l.Annotations["org.opencontainers.image.title"])
+		if match(title, strings.ToLower(l.MediaType)) {
+			return l, true
+		}
+	}
+	return ociDescriptor{}, false
+}
+
+// isMarkdownLayer identifies the rendered changelog layer by filename suffix or media type.
+func isMarkdownLayer(title, mediaType string) bool {
+	return strings.HasSuffix(title, changelogMarkdownSuffix) || strings.Contains(mediaType, "markdown")
+}
+
+// isVersionLayer identifies the computed-version layer (a bare "version"/"VERSION" file).
+func isVersionLayer(title, _ string) bool {
+	base := title
+	if i := strings.LastIndex(title, "/"); i >= 0 {
+		base = title[i+1:]
+	}
+	return base == "version" || strings.HasSuffix(title, ".version")
+}
+
+// statusError represents a non-2xx HTTP response from the registry.
+type statusError struct {
+	status int
+	what   string
+	body   string
+}
+
+func (e *statusError) Error() string {
+	return fmt.Sprintf("%s: unexpected status %d: %s", e.what, e.status, e.body)
+}
+
+// cacheMissError marks a structural cache miss (a resolved artifact that is unusable: missing
+// markdown layer or empty markdown) so the caller falls back to chronicle without burning the
+// retry budget.
+type cacheMissError struct {
+	reason string
+}
+
+func (e *cacheMissError) Error() string { return e.reason }
+
+// isRetryable reports whether an error is worth retrying. Transport errors and transient server
+// responses (5xx, rate limiting) are; definitive client responses (a missing artifact, auth
+// problems) and structural misses are not, so the caller falls back to chronicle without burning
+// the retry budget.
+func isRetryable(err error) bool {
+	var miss *cacheMissError
+	if errors.As(err, &miss) {
+		return false
+	}
+	var s *statusError
+	if errors.As(err, &s) {
+		return s.status >= 500 || s.status == http.StatusTooManyRequests
+	}
+	return true
+}
+
+// projectName derives the changelog artifact's project name from the module path, e.g.
+// github.com/anchore/syft -> syft (ignoring any trailing major-version suffix like /v2).
+func projectName() (name string, err error) {
+	// gomod.Read panics if go.mod can't be read or parsed; recover so a setup failure degrades
+	// to the chronicle fallback instead of aborting the release.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("unable to determine project name: %v", r)
+		}
+	}()
+
+	m := gomod.Read()
+	if m == nil || m.Module == nil {
+		return "", fmt.Errorf("unable to determine project name: no go.mod module path found")
+	}
+	path := majorVersionSuffix.ReplaceAllString(m.Module.Mod.Path, "")
+	return path[strings.LastIndex(path, "/")+1:], nil
+}
+
+func githubToken() string {
+	if t := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); t != "" {
+		return t
+	}
+	return strings.TrimSpace(Run("gh auth token", run.NoFail()))
+}
+
+func basicAuth(user, pass string) string {
+	return base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+}
+
+// truncate trims and shortens a registry error body to a bounded length, counting runes so it
+// never splits a multi-byte UTF-8 sequence before the ellipsis.
+func truncate(b []byte) string {
+	const max = 256
+	s := strings.TrimSpace(string(b))
+	r := []rune(s)
+	if len(r) > max {
+		return string(r[:max]) + "..."
+	}
+	return s
+}

--- a/tasks/release/changelog_cache_test.go
+++ b/tasks/release/changelog_cache_test.go
@@ -1,0 +1,409 @@
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/anchore/go-make/require"
+)
+
+func TestFindMarkdownLayer(t *testing.T) {
+	tests := []struct {
+		name       string
+		layers     []ociDescriptor
+		wantDigest string
+		wantFound  bool
+	}{
+		{
+			name: "match by title annotation",
+			layers: []ociDescriptor{
+				{Digest: "sha256:json", Annotations: map[string]string{"org.opencontainers.image.title": "changelog.json"}},
+				{Digest: "sha256:md", Annotations: map[string]string{"org.opencontainers.image.title": "CHANGELOG.md"}},
+				{Digest: "sha256:ver", Annotations: map[string]string{"org.opencontainers.image.title": "VERSION"}},
+			},
+			wantDigest: "sha256:md",
+			wantFound:  true,
+		},
+		{
+			name: "fall back to markdown media type",
+			layers: []ociDescriptor{
+				{Digest: "sha256:json", MediaType: "application/json"},
+				{Digest: "sha256:md", MediaType: "text/markdown"},
+			},
+			wantDigest: "sha256:md",
+			wantFound:  true,
+		},
+		{
+			name: "no markdown layer",
+			layers: []ociDescriptor{
+				{Digest: "sha256:json", Annotations: map[string]string{"org.opencontainers.image.title": "changelog.json"}},
+			},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, found := findLayer(tt.layers, isMarkdownLayer)
+			require.Equal(t, tt.wantFound, found)
+			if !found {
+				return
+			}
+			require.Equal(t, tt.wantDigest, got.Digest)
+		})
+	}
+}
+
+func TestOCIClientPullMarkdown(t *testing.T) {
+	const (
+		repo    = "anchore/changelog/test"
+		ref     = "abcdef"
+		blob    = "sha256:deadbeef"
+		verBlob = "sha256:cafe"
+		body    = "# Changelog\n\n- a great change\n"
+		verBody = "v1.2.3\n"
+	)
+
+	tests := []struct {
+		name          string
+		handler       http.HandlerFunc
+		want          cachedChangelog
+		wantErr       require.ValidationError
+		wantRetryable bool
+	}{
+		{
+			name: "happy path with markdown and version layers",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/token"):
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+				case strings.HasSuffix(r.URL.Path, "/manifests/"+ref):
+					require.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+					_ = json.NewEncoder(w).Encode(ociManifest{
+						Layers: []ociDescriptor{
+							{Digest: blob, Annotations: map[string]string{"org.opencontainers.image.title": "CHANGELOG.md"}},
+							{Digest: verBlob, Annotations: map[string]string{"org.opencontainers.image.title": "VERSION"}},
+						},
+					})
+				case strings.HasSuffix(r.URL.Path, "/blobs/"+blob):
+					_, _ = w.Write([]byte(body))
+				case strings.HasSuffix(r.URL.Path, "/blobs/"+verBlob):
+					_, _ = w.Write([]byte(verBody))
+				default:
+					http.Error(w, "not found", http.StatusNotFound)
+				}
+			},
+			want: cachedChangelog{markdown: body, version: "v1.2.3"},
+		},
+		{
+			name: "index is resolved to child manifest",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/token"):
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+				case strings.HasSuffix(r.URL.Path, "/manifests/"+ref):
+					_ = json.NewEncoder(w).Encode(ociManifest{
+						MediaType: "application/vnd.oci.image.index.v1+json",
+						Manifests: []ociDescriptor{{Digest: "sha256:child"}},
+					})
+				case strings.HasSuffix(r.URL.Path, "/manifests/sha256:child"):
+					_ = json.NewEncoder(w).Encode(ociManifest{
+						Layers: []ociDescriptor{{
+							Digest:      blob,
+							Annotations: map[string]string{"org.opencontainers.image.title": "CHANGELOG.md"},
+						}},
+					})
+				case strings.HasSuffix(r.URL.Path, "/blobs/"+blob):
+					_, _ = w.Write([]byte(body))
+				default:
+					http.Error(w, "not found", http.StatusNotFound)
+				}
+			},
+			want: cachedChangelog{markdown: body},
+		},
+		{
+			name: "self-referential index errors at the depth limit",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/token"):
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+				default:
+					// every manifest is an index pointing back at another manifest, so
+					// resolution would loop forever without the depth guard.
+					_ = json.NewEncoder(w).Encode(ociManifest{
+						MediaType: "application/vnd.oci.image.index.v1+json",
+						Manifests: []ociDescriptor{{Digest: "sha256:loop"}},
+					})
+				}
+			},
+			wantErr:       require.Error,
+			wantRetryable: true,
+		},
+		{
+			name: "auth failure at token endpoint is not retryable",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+			},
+			wantErr:       require.Error,
+			wantRetryable: false,
+		},
+		{
+			name: "auth failure pulling manifest is not retryable",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasPrefix(r.URL.Path, "/token") {
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+					return
+				}
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+			},
+			wantErr:       require.Error,
+			wantRetryable: false,
+		},
+		{
+			name: "not found is not retryable",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasPrefix(r.URL.Path, "/token") {
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+					return
+				}
+				http.Error(w, "no such artifact", http.StatusNotFound)
+			},
+			wantErr:       require.Error,
+			wantRetryable: false,
+		},
+		{
+			name: "server error is retryable",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if strings.HasPrefix(r.URL.Path, "/token") {
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+					return
+				}
+				http.Error(w, "boom", http.StatusServiceUnavailable)
+			},
+			wantErr:       require.Error,
+			wantRetryable: true,
+		},
+		{
+			name: "transport drop mid-read is retryable, not a structural miss",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/token"):
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+				case strings.HasSuffix(r.URL.Path, "/manifests/"+ref):
+					_ = json.NewEncoder(w).Encode(ociManifest{
+						Layers: []ociDescriptor{{
+							Digest:      blob,
+							Annotations: map[string]string{"org.opencontainers.image.title": "CHANGELOG.md"},
+						}},
+					})
+				case strings.HasSuffix(r.URL.Path, "/blobs/"+blob):
+					// promise more bytes than we send, then drop the connection so the client's
+					// read fails mid-stream instead of returning a complete body.
+					w.Header().Set("Content-Length", "4096")
+					_, _ = w.Write([]byte("# partial changelog"))
+					if f, ok := w.(http.Flusher); ok {
+						f.Flush()
+					}
+					if hj, ok := w.(http.Hijacker); ok {
+						conn, _, err := hj.Hijack()
+						if err == nil {
+							_ = conn.Close()
+						}
+					}
+				default:
+					http.Error(w, "not found", http.StatusNotFound)
+				}
+			},
+			wantErr:       require.Error,
+			wantRetryable: true,
+		},
+		{
+			name: "missing markdown layer is a non-retryable miss",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/token"):
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+				default:
+					_ = json.NewEncoder(w).Encode(ociManifest{
+						Layers: []ociDescriptor{{
+							Digest:      "sha256:json",
+							Annotations: map[string]string{"org.opencontainers.image.title": "changelog.json"},
+						}},
+					})
+				}
+			},
+			wantErr:       require.Error,
+			wantRetryable: false,
+		},
+		{
+			name: "empty markdown is a non-retryable miss",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.HasPrefix(r.URL.Path, "/token"):
+					_ = json.NewEncoder(w).Encode(map[string]string{"token": "test-token"})
+				case strings.HasSuffix(r.URL.Path, "/manifests/"+ref):
+					_ = json.NewEncoder(w).Encode(ociManifest{
+						Layers: []ociDescriptor{{
+							Digest:      blob,
+							Annotations: map[string]string{"org.opencontainers.image.title": "CHANGELOG.md"},
+						}},
+					})
+				case strings.HasSuffix(r.URL.Path, "/blobs/"+blob):
+					_, _ = w.Write([]byte("   \n\t  "))
+				default:
+					http.Error(w, "not found", http.StatusNotFound)
+				}
+			},
+			wantErr:       require.Error,
+			wantRetryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(tt.handler)
+			defer srv.Close()
+
+			u, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			c := &ociClient{
+				scheme:   u.Scheme,
+				registry: u.Host,
+				repo:     repo,
+				ghToken:  "fake-token",
+				http:     srv.Client(),
+			}
+
+			got, err := c.pull(context.Background(), ref)
+			tt.wantErr.Validate(t, err)
+
+			if err != nil {
+				require.Equal(t, tt.wantRetryable, isRetryable(err))
+				return
+			}
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestGetChangelogFallback exercises the fallback decision and version precedence: a cache hit
+// lacking a version degrades to chronicle when the caller needs one, a usable cache hit is served
+// from the cache, and a caller-supplied tag (the publish path) always wins over the cached version.
+func TestGetChangelogFallback(t *testing.T) {
+	tests := []struct {
+		name         string
+		cached       cachedChangelog
+		fetchErr     error
+		inputVersion string
+		wantFallback bool
+		wantShown    bool
+		wantVersion  string
+	}{
+		{
+			name:         "cache hit without version falls back when caller needs one",
+			cached:       cachedChangelog{markdown: "md"},
+			inputVersion: "",
+			wantFallback: true,
+			wantVersion:  "fell-back",
+		},
+		{
+			name:         "cache hit with version is served from the cache",
+			cached:       cachedChangelog{markdown: "md", version: "v1.2.3"},
+			inputVersion: "",
+			wantShown:    true,
+			wantVersion:  "v1.2.3",
+		},
+		{
+			name:         "cache miss falls back",
+			fetchErr:     errors.New("boom"),
+			inputVersion: "",
+			wantFallback: true,
+			wantVersion:  "fell-back",
+		},
+		{
+			name:         "caller-supplied version wins when cache lacks one",
+			cached:       cachedChangelog{markdown: "md"},
+			inputVersion: "v9.9.9",
+			wantShown:    true,
+			wantVersion:  "v9.9.9",
+		},
+		{
+			name:         "caller-supplied version wins over a differing cached version",
+			cached:       cachedChangelog{markdown: "md", version: "v1.2.3"},
+			inputVersion: "v9.9.9",
+			wantShown:    true,
+			wantVersion:  "v9.9.9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fellBack, shown bool
+
+			require.SetAndRestore(t, &fetchCachedChangelogFn, func() (cachedChangelog, error) {
+				return tt.cached, tt.fetchErr
+			})
+			require.SetAndRestore(t, &fallbackChangelogFn, func(string) (string, string) {
+				fellBack = true
+				return changelogFile, "fell-back"
+			})
+			require.SetAndRestore(t, &writeAndShowFn, func(cachedChangelog) {
+				shown = true
+			})
+
+			path, version := GetChangelog(tt.inputVersion)
+			require.Equal(t, changelogFile, path)
+			require.Equal(t, tt.wantVersion, version)
+			require.Equal(t, tt.wantFallback, fellBack)
+			require.Equal(t, tt.wantShown, shown)
+		})
+	}
+}
+
+func TestIsVersionLayer(t *testing.T) {
+	tests := []struct {
+		title string
+		want  bool
+	}{
+		{title: "version", want: true},
+		{title: "VERSION", want: true}, // matched case-insensitively via findLayer, but verify lowercased form
+		{title: "changelog.version", want: true},
+		{title: "path/to/version", want: true},
+		{title: "changelog.md", want: false},
+		{title: "changelog.json", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.title, func(t *testing.T) {
+			require.Equal(t, tt.want, isVersionLayer(strings.ToLower(tt.title), ""))
+		})
+	}
+}
+
+func TestBasicAuth(t *testing.T) {
+	// "user:pass" base64-encoded
+	require.Equal(t, "dXNlcjpwYXNz", basicAuth("user", "pass"))
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "short is unchanged", in: "  hello  ", want: "hello"},
+		{name: "long is truncated", in: strings.Repeat("x", 300), want: strings.Repeat("x", 256) + "..."},
+		{name: "multi-byte runes are not split", in: strings.Repeat("é", 300), want: strings.Repeat("é", 256) + "..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, truncate([]byte(tt.in)))
+		})
+	}
+}

--- a/tasks/release/release.go
+++ b/tasks/release/release.go
@@ -44,8 +44,9 @@ func TagReleaseTask() Task {
 			// this ensures we are in CI and will tag HEAD and push using the configured credential
 			ci.PublishTag(tagName)
 
-			// generate changelog for the version (needs the tag to exist locally)
-			changelogFile := GenerateAndShowFromVersion(tagName)
+			// fetch the pre-built changelog from the OCI cache (falls back to generating it
+			// with chronicle if the cache is unavailable)
+			changelogFile, _ := GetChangelog(tagName)
 
 			// use --verify-tag to abort if the tag doesn't already exist on remote
 			Run("gh release create --latest --verify-tag",

--- a/tasks/release/workflow.go
+++ b/tasks/release/workflow.go
@@ -55,11 +55,9 @@ func WorkflowReleaseTask() Task {
 			// ensure we have up-to-date git tags
 			Run("git fetch --tags")
 
-			GenerateAndShowChangelog()
-
-			// read next version from VERSION file
-			version := file.Read(versionFile)
-			nextVersion := strings.TrimSpace(version)
+			// use the pre-built changelog (and the version it carries) from the OCI cache,
+			// falling back to generating it with chronicle if the cache is unavailable
+			_, nextVersion := GetChangelog("")
 
 			if nextVersion == "" || nextVersion == "(Unreleased)" {
 				log.Info("Could not determine the next version to release. Exiting...")


### PR DESCRIPTION
We are now generating candidate changelogs on commit to main, which we want to leverage when kicking off releases instead of regenerating (especially with the new syft and grype integrations). This enables the existing targets that use changelog in the release workflow to attempt to leverage this cache (from an OCI registry) and if that does not succeed then to fallback to generating the cahngelog as we do today (without the syft and grype integrations).